### PR TITLE
Password updates and Bearer auth instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 ### Integration with other services
 
+In order to use the auth microservice with other applications, you will need to protect your API resources with a JWT strategy. The easiest way to do this is with [Passport JWT](https://www.npmjs.com/package/passport-jwt), which is what this repository uses for its own protected resources. For direct examples of how we set up the strategy, take a look at [passport.js](./config/passport.js), [express.js](./config/express.js), and [auth.route.js](./server/routes/auth.route.js).
+
+In general, the authentication flow will be as follows:
+1. `POST /login` with username and password to get a token.
+2. Send the JWT in a header `Authorization: Bearer <JWT>` when using a protected resource.
+
+It is the responsibility of the integrated service to extract the JWT, verify it against a shared secret or public/private key pair, and use it to fetch information on the authenticated User.
+For example, one API endpoint could allow _any_ authenticated user to view certain information about all users. Another endpoint may allow password updates, but only for the specific authenticated user. It is up to the developer to ensure that endpoints are protected appropriately.
+
+#### Roles
+// TODO
+
 ### API Spec
 
 ### Features

--- a/config/express.js
+++ b/config/express.js
@@ -9,11 +9,13 @@ import httpStatus from 'http-status';
 import expressWinston from 'express-winston';
 import expressValidation from 'express-validation';
 import helmet from 'helmet';
+import passport from 'passport';
 import Sequelize from 'sequelize';
 import winstonInstance from './winston';
 import routes from '../server/routes/index.route';
 import config from './config';
 import APIError from '../server/helpers/APIError';
+import passportConfig from './passport';
 
 const app = express();
 
@@ -46,6 +48,11 @@ if (config.env === 'development') {
         colorStatus: true, // Color the status code (default green, 3XX cyan, 4XX yellow, 5XX red).
     }));
 }
+
+// set up Passport middleware
+passportConfig(passport);
+app.use(passport.initialize());
+
 
 // mount all routes on /api path
 app.use('/api', routes);

--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -13,6 +13,11 @@ export default {
             email: Joi.string().email(),
         },
     },
+    updatePassword: {
+        body: {
+            password: Joi.string().min(8).max(64).required(),
+        },
+    },
     login: {
         body: {
             username: Joi.string().required(),

--- a/config/passport.js
+++ b/config/passport.js
@@ -1,0 +1,26 @@
+import {
+    Strategy as JwtStrategy,
+    ExtractJwt,
+} from 'passport-jwt';
+import { User } from './sequelize';
+import config from './config';
+
+const opts = {
+    jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+    secretOrKey: config.jwtSecret,
+};
+
+module.exports = (passport) => {
+    passport.use(new JwtStrategy(opts, (jwtPayload, done) => {
+        User.findOne({ where: { username: jwtPayload.username } }, (err, user) => {
+            if (err) {
+                return done(err, false);
+            } else if (user) {
+                return done(null, user);
+            }
+            return done(null, false);
+                // or you could create a new account
+        });
+    }));
+};
+

--- a/config/passport.js
+++ b/config/passport.js
@@ -12,15 +12,9 @@ const opts = {
 
 module.exports = (passport) => {
     passport.use(new JwtStrategy(opts, (jwtPayload, done) => {
-        User.findOne({ where: { username: jwtPayload.username } }, (err, user) => {
-            if (err) {
-                return done(err, false);
-            } else if (user) {
-                return done(null, user);
-            }
-            return done(null, false);
-                // or you could create a new account
-        });
+        User.findOne({ where: { username: jwtPayload.username } })
+            .then(user => done(null, user))
+            .catch(err => done(err, false));
     }));
 };
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "lodash": "4.17.4",
     "method-override": "^2.3.5",
     "morgan": "1.8.2",
+    "passport": "0.4.0",
+    "passport-jwt": "3.0.0",
     "pg": "6.1.6",
     "pg-hstore": "2.3.2",
     "run-sequence": "^1.1.5",

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -46,4 +46,13 @@ function login(req, res, next) {
 
 function logout() {}
 
-export default { login, logout };
+/**
+ * Returns 200 OK if password was updated successfully
+ * @param req
+ * @param res
+ * @param next
+ * @returns {*}
+ */
+function updatePassword() {}
+
+export default { login, logout, updatePassword };

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -53,6 +53,16 @@ function logout() {}
  * @param next
  * @returns {*}
  */
-function updatePassword() {}
+function updatePassword(req, res, next) {
+    const user = req.user;
+    user.password = req.body.password;
+    user.save()
+        .then(() => {
+            return res.sendStatus(httpStatus.OK)
+        })
+        .catch(error => next(error));
+        // TODO should we produce a new token? A user could change the password
+        // and change it again without re-authenticating
+}
 
 export default { login, logout, updatePassword };

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -11,11 +11,11 @@ router.route('/login')
 
 router.route('/logout');
 
-router.route('/update_password')
+router.route('/update-password')
     .post(validate(paramValidation.updatePassword),
           passport.authenticate('jwt', { session: false }),
           authCtrl.updatePassword);
 
-router.route('/forgot_password');
+router.route('/forgot-password');
 
 export default router;

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import validate from 'express-validation';
+import passport from 'passport';
 import paramValidation from '../../config/param-validation';
 import authCtrl from '../controllers/auth.controller';
 
@@ -9,5 +10,12 @@ router.route('/login')
     .post(validate(paramValidation.login), authCtrl.login);
 
 router.route('/logout');
+
+router.route('/update_password')
+    .post(validate(paramValidation.updatePassword),
+          passport.authenticate('jwt', { session: false }),
+          authCtrl.updatePassword);
+
+router.route('/forgot_password');
 
 export default router;

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -107,7 +107,7 @@ describe('Auth API:', () => {
 
     // describe('# POST /auth/logout');
 
-    describe('POST /auth/reset-password', () => {
+    describe('POST /auth/update-password', () => {
         before((done) => {
             request(app)
                 .post(`${baseURL}/user`)
@@ -121,7 +121,7 @@ describe('Auth API:', () => {
 
         after(() => User.destroy({ where: {} }));
 
-        beforeEach((done) => {
+        before((done) => {
             request(app)
                 .post(`${baseURL}/auth/login`)
                 .send(validUserCredentials)
@@ -140,28 +140,29 @@ describe('Auth API:', () => {
 
         it('should update user password when user is authenticated', (done) => {
             request(app)
-                .post(`${baseURL}/auth/reset-password`)
-                .set('Authorization', `Bearer ${jwtToken}`)
+                .post(`${baseURL}/auth/update-password`)
+                .set('Authorization', jwtToken)
                 .send({
                     password: 'newerpass',
                 })
                 .expect(httpStatus.OK)
                 .then((res) => {
-                    expect(res.body.message).to.equal('OK');
+                    expect(res.text).to.equal('OK');
                     done();
                 })
                 .catch(done);
         });
 
         it('should return 401 when user is not authenticated', (done) => {
+            console.log(jwtToken);
             request(app)
-                .post(`${baseURL}/auth/reset-password`)
-                .set('Authorization', `Bearer ${jwtToken}`)
+                .post(`${baseURL}/auth/update-password`)
                 .send({
                     password: 'newerpass',
                 })
-                .expect(httpStatus.OK)
-                .then(() => {
+                .expect(httpStatus.UNAUTHORIZED)
+                .then((res) => {
+                    expect(res.text).to.equal('Unauthorized');
                     done();
                 })
                 .catch(done);
@@ -169,13 +170,14 @@ describe('Auth API:', () => {
 
         it('should return 401 when JWT is invalid', (done) => {
             request(app)
-                .post(`${baseURL}/auth/reset-password`)
-                .set('Authorization', `Bearer ${jwtToken}`)
+                .post(`${baseURL}/auth/update-password`)
+                .set('Authorization', 'Bearer BadJWT')
                 .send({
                     password: 'newerpass',
                 })
-                .expect(httpStatus.OK)
-                .then(() => {
+                .expect(httpStatus.UNAUTHORIZED)
+                .then((res) => {
+                    expect(res.text).to.equal('Unauthorized');
                     done();
                 })
                 .catch(done);
@@ -183,8 +185,8 @@ describe('Auth API:', () => {
 
         it('should return 400 if password is invalid', (done) => {
             request(app)
-                .post(`${baseURL}/auth/reset-password`)
-                .set('Authorization', `Bearer ${jwtToken}`)
+                .post(`${baseURL}/auth/update-password`)
+                .set('Authorization', jwtToken)
                 .send({
                     password: 'badpass',
                 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3061,6 +3061,16 @@ jsonwebtoken@7.4.1, jsonwebtoken@^7.3.0:
     ms "^2.0.0"
     xtend "^4.0.1"
 
+jsonwebtoken@^7.0.0:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz#77f5021de058b605a1783fa1283e99812e645638"
+  dependencies:
+    joi "^6.10.1"
+    jws "^3.1.4"
+    lodash.once "^4.0.0"
+    ms "^2.0.0"
+    xtend "^4.0.1"
+
 jsprim@^1.2.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"
@@ -3891,6 +3901,24 @@ parseurl@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
 
+passport-jwt@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/passport-jwt/-/passport-jwt-3.0.0.tgz#7d9e4ff0fa0522108540ce1fcfa83bbd8faa29c9"
+  dependencies:
+    jsonwebtoken "^7.0.0"
+    passport-strategy "^1.0.0"
+
+passport-strategy@1.x.x, passport-strategy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
+
+passport@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/passport/-/passport-0.4.0.tgz#c5095691347bd5ad3b5e180238c3914d16f05811"
+  dependencies:
+    passport-strategy "1.x.x"
+    pause "0.0.1"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -3936,6 +3964,10 @@ pause-stream@0.0.11:
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   dependencies:
     through "~2.3"
+
+pause@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
 
 performance-now@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
#### What's this PR do?
Allows users to make password updates via a protected endpoint. This endpoint is protected with Passport JWT for Bearer auth. The repo includes documentation for how to implement this strategy for your own services, in order to integrate with the auth service.

#### Related JIRA tickets:
SER-7, SER-8

#### How should this be manually tested?
You can use the following cURL commands to create a user, authenticate, and submit a password change. You should then try re-authenticating with the new password.

```curl
## Create User
curl -X "POST" "http://localhost:4000/api/user" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d $'{
  "email": "test@amida.com",
  "username": "test123",
  "password": "testpass"
}'

## Login
curl -X "POST" "http://localhost:4000/api/auth/login" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d $'{
  "username": "test123",
  "password": "testpass"
}'

## Update Password
curl -X "POST" "http://localhost:4000/api/auth/update-password" \
     -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6InRlc3QxMjMiLCJpYXQiOjE1MDQxMjcxNTQsImV4cCI6MTUwNDEzMDc1NH0.VHT3h8e6Nd6eTlhteWU6F0J9ouID-l5QRO9FvZan104" \
     -H "Content-Type: application/json; charset=utf-8" \
     -d $'{
  "password": "newerpass"
}'

```