### PR TITLE
Add scopes, scope modification, and scope validation

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 
-export default {
+const userValidation = {
     createUser: {
         body: {
             username: Joi.string().required(),
@@ -18,6 +18,9 @@ export default {
             scopes: Joi.array().unique().items(Joi.string().allow('')).required(),
         },
     },
+};
+
+const authValidation = {
     updatePassword: {
         body: {
             password: Joi.string().min(8).max(64).required(),
@@ -39,4 +42,9 @@ export default {
             password: Joi.string().required(),
         },
     },
+};
+
+export default {
+    userValidation,
+    authValidation,
 };

--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -13,6 +13,11 @@ export default {
             email: Joi.string().email(),
         },
     },
+    updateUserScopes: {
+        body: {
+            scopes: Joi.array().unique().items(Joi.string().allow('')).required(),
+        },
+    },
     updatePassword: {
         body: {
             password: Joi.string().min(8).max(64).required(),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:watch": "yarn lint -- --watch",
     "beautify": "esw -c .eslintrc *.js server config --color --fix",
     "precommit": "yarn lint && yarn test",
-    "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --ui bdd --reporter spec --colors --compilers js:babel-core/register server/tests --recursive",
+    "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --ui bdd --reporter spec --colors --compilers js:babel-core/register server/tests --recursive -t 3000",
     "test:watch": "yarn test -- --watch",
     "test:coverage": "cross-env NODE_ENV=test ./node_modules/.bin/istanbul cover _mocha -- --ui bdd --reporter spec --colors --compilers js:babel-core/register server/tests --recursive",
     "test:check-coverage": "yarn test:coverage && istanbul check-coverage",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "dotenv": "^4.0.0",
     "express": "4.15.3",
     "express-jwt": "5.3.0",
+    "express-jwt-permissions": "1.0.0",
     "express-validation": "1.0.1",
     "express-winston": "2.1.2",
     "gulp": "3.9.1",

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -24,23 +24,23 @@ function load(req, res, next, id) {
 
 /**
  * Get user
- * @returns {User}
+ * Returns JSON of the specified user
  */
 function get(req, res) {
     return res.json(req.user);
 }
 
 /**
- * Create new user
- * @property {string} req.body.username - The username of the new user.
- * @property {string} req.body.email - The email of the new user.
- * @returns {User}
+ * Create and save a new user
+ * Returns JSON of the saved user
+ * TODO: this should return a virtual, omitting sensitive info
  */
 function create(req, res, next) {
     const user = User.build({
         username: req.body.username,
         email: req.body.email,
         password: req.body.password,
+        scopes: req.body.scopes,
     });
 
     user.save()
@@ -49,6 +49,18 @@ function create(req, res, next) {
 }
 
 function update() {}
+
+/**
+ * Update authorization scopes for a given user.
+ * Overwrites existing scopes array with the provided one.
+ * Returns JSON of the updated user.
+ */
+function updateScopes(req, res, next) {
+    req.user
+        .update({ scopes: req.body.scopes })
+        .then(updatedUser => res.json(updatedUser))
+        .catch(e => next(e));
+}
 
 function list() {}
 
@@ -61,6 +73,7 @@ export default {
     get,
     create,
     update,
+    updateScopes,
     list,
     remove,
     me,

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -56,8 +56,8 @@ function update() {}
  * Returns JSON of the updated user.
  */
 function updateScopes(req, res, next) {
-    req.user
-        .update({ scopes: req.body.scopes })
+    User.findById(req.params.userId)
+        .then(user => user.update({ scopes: req.body.scopes }))
         .then(updatedUser => res.json(updatedUser))
         .catch(e => next(e));
 }

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -50,6 +50,7 @@ module.exports = (sequelize, DataTypes) => {
         scopes: {
             type: DataTypes.ARRAY(DataTypes.STRING),
             allowNull: true,
+            default: [''],
         },
         resetToken: {
             type: DataTypes.STRING,

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -1,27 +1,27 @@
 import express from 'express';
 import validate from 'express-validation';
 import passport from 'passport';
-import paramValidation from '../../config/param-validation';
+import { authValidation } from '../../config/param-validation';
 import authCtrl from '../controllers/auth.controller';
 
 const router = express.Router(); // eslint-disable-line new-cap
 
 router.route('/login')
-    .post(validate(paramValidation.login), authCtrl.login);
+    .post(validate(authValidation.login), authCtrl.login);
 
 router.route('/logout');
 
 router.route('/update-password')
-    .post(validate(paramValidation.updatePassword),
+    .post(validate(authValidation.updatePassword),
           passport.authenticate('jwt', { session: false }),
           authCtrl.updatePassword);
 
 router.route('/reset-password')
-    .post(validate(paramValidation.resetToken),
+    .post(validate(authValidation.resetToken),
           authCtrl.resetToken);
 
 router.route('/reset-password/:token')
-    .post(validate(paramValidation.resetPassword),
+    .post(validate(authValidation.resetPassword),
           authCtrl.resetPassword);
 
 export default router;

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -2,7 +2,7 @@ import express from 'express';
 import validate from 'express-validation';
 import guard from 'express-jwt-permissions';
 import passport from 'passport';
-import paramValidation from '../../config/param-validation';
+import { userValidation } from '../../config/param-validation';
 import userCtrl from '../controllers/user.controller';
 
 const router = express.Router(); // eslint-disable-line new-cap
@@ -13,21 +13,21 @@ router.route('/')
     .get(userCtrl.list)
 
     /** POST /api/users - Create new user */
-    .post(validate(paramValidation.createUser), userCtrl.create);
+    .post(validate(userValidation.createUser), userCtrl.create);
 
 router.route('/:userId')
     /** GET /api/users/:userId - Get user */
     .get(userCtrl.get)
 
     /** PUT /api/users/:userId - Update user */
-    .put(validate(paramValidation.updateUser), userCtrl.update)
+    .put(validate(userValidation.updateUser), userCtrl.update)
 
     /** DELETE /api/users/:userId - Delete user */
     .delete(userCtrl.remove);
 
 router.route('/scopes/:userId')
     /** PUT /api/user/scopes/:userId - Update user scopes */
-    .put(validate(paramValidation.updateUserScopes),
+    .put(validate(userValidation.updateUserScopes),
          passport.authenticate('jwt', { session: false }),
          permissions.check('admin'),
          userCtrl.updateScopes);

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -6,7 +6,7 @@ import paramValidation from '../../config/param-validation';
 import userCtrl from '../controllers/user.controller';
 
 const router = express.Router(); // eslint-disable-line new-cap
-const permissions = guard({permissionsProperty: 'scopes'});
+const permissions = guard({ permissionsProperty: 'scopes' });
 
 router.route('/')
     /** GET /api/users - Get list of users */
@@ -26,7 +26,7 @@ router.route('/:userId')
     .delete(userCtrl.remove);
 
 router.route('/scopes/:userId')
-    /** PUT /api/users/scopes/:userId - Update user scopes */
+    /** PUT /api/user/scopes/:userId - Update user scopes */
     .put(validate(paramValidation.updateUserScopes),
          passport.authenticate('jwt', { session: false }),
          permissions.check('admin'),

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -1,9 +1,12 @@
 import express from 'express';
 import validate from 'express-validation';
+import guard from 'express-jwt-permissions';
+import passport from 'passport';
 import paramValidation from '../../config/param-validation';
 import userCtrl from '../controllers/user.controller';
 
 const router = express.Router(); // eslint-disable-line new-cap
+const permissions = guard({permissionsProperty: 'scopes'});
 
 router.route('/')
     /** GET /api/users - Get list of users */
@@ -13,7 +16,6 @@ router.route('/')
     .post(validate(paramValidation.createUser), userCtrl.create);
 
 router.route('/:userId')
-
     /** GET /api/users/:userId - Get user */
     .get(userCtrl.get)
 
@@ -22,6 +24,13 @@ router.route('/:userId')
 
     /** DELETE /api/users/:userId - Delete user */
     .delete(userCtrl.remove);
+
+router.route('/scopes/:userId')
+    /** PUT /api/users/scopes/:userId - Update user scopes */
+    .put(validate(paramValidation.updateUserScopes),
+         passport.authenticate('jwt', { session: false }),
+         permissions.check('admin'),
+         userCtrl.updateScopes);
 
 router.route('/me')
     .get(userCtrl.me);

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -241,10 +241,12 @@ describe('User API:', () => {
                     scopes: ['newScope'],
                 })
                 .expect(httpStatus.OK)
-                .then((userRes) => {
-                    expect(userRes.body.scopes).to.deep.equal(['newScope']);
-                    return;
-                })
+                .then(() => request(app)
+                        .get(`${baseURL}/user/${userId}`)
+                        .then((userRes) => {
+                            expect(userRes.body.scopes).to.deep.equal(['newScope']);
+                            return;
+                        }))
         );
 
         it('should work with an empty array update', () =>

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -30,6 +30,11 @@ describe('User API:', () => {
         password: 'testpass',
     };
 
+    const userCredentials = {
+        username: 'KK123',
+        password: 'testpass',
+    };
+
     const userBadPassword = {
         username: 'KK123',
         email: 'test@amida.com',
@@ -54,9 +59,21 @@ describe('User API:', () => {
         password: 'testpass',
     };
 
+    const adminUser = {
+        username: 'admin',
+        email: 'admin@amida.com',
+        password: 'adminpass',
+        scopes: ['admin'],
+    };
+
+    const adminUserCredentials = {
+        username: 'admin',
+        password: 'adminpass',
+    };
+
     beforeEach(() => User.destroy({ where: {} }));
 
-    describe('# POST /api/users', () => {
+    describe('POST /api/user:', () => {
         it('should create a new user and return it without password info', (done) => {
             request(app)
                 .post(`${baseURL}/user`)
@@ -145,5 +162,103 @@ describe('User API:', () => {
                 })
                 .catch(done);
         });
+    });
+
+    describe(('PUT /api/user/scopes/:userId'), () => {
+        let userId;
+        let jwtToken;
+
+        beforeEach(() => request(app)
+            .post(`${baseURL}/user`)
+            .send(adminUser)
+            .expect(httpStatus.OK)
+        );
+
+        beforeEach(() => request(app)
+            .post(`${baseURL}/user`)
+            .send(user)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                userId = res.body.id;
+                return;
+            })
+        );
+
+        beforeEach(() => request(app)
+            .post(`${baseURL}/auth/login`)
+            .send(adminUserCredentials)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.have.property('token');
+                jwtToken = `Bearer ${res.body.token}`;
+                return;
+            })
+        );
+
+        it('should require admin permissions to use this route', () =>
+            request(app)
+                .post(`${baseURL}/auth/login`)
+                .send(userCredentials)
+                .expect(httpStatus.OK)
+                .then((res) => {
+                    expect(res.body).to.have.property('token');
+                    jwtToken = `Bearer ${res.body.token}`;
+                    return request(app)
+                        .put(`${baseURL}/user/scopes/${userId}`)
+                        .set('Authorization', jwtToken)
+                        .send({
+                            scopes: ['newScope'],
+                        })
+                        .expect(httpStatus.FORBIDDEN);
+                })
+        );
+
+        it('should reject updates to scopes not using an array', () =>
+            request(app)
+                .put(`${baseURL}/user/scopes/${userId}`)
+                .set('Authorization', jwtToken)
+                .send({
+                    scopes: 'badscope',
+                })
+                .expect(httpStatus.BAD_REQUEST)
+        );
+
+        it('should reject updates with duplicate values', () =>
+            request(app)
+                .put(`${baseURL}/user/scopes/${userId}`)
+                .set('Authorization', jwtToken)
+                .send({
+                    scopes: ['notUnique', 'notUnique'],
+                })
+                .expect(httpStatus.BAD_REQUEST)
+        );
+
+        it('should overwrite the old array', () =>
+            request(app)
+                .put(`${baseURL}/user/scopes/${userId}`)
+                .set('Authorization', jwtToken)
+                .send({
+                    scopes: ['newScope'],
+                })
+                .expect(httpStatus.OK)
+                .then((userRes) => {
+                    expect(userRes.body.scopes).to.deep.equal(['newScope']);
+                    return;
+                })
+        );
+
+        it('should work with an empty array update', () =>
+            request(app)
+                .put(`${baseURL}/user/scopes/${userId}`)
+                .set('Authorization', jwtToken)
+                .send({
+                    scopes: [''],
+                })
+                .expect(httpStatus.OK)
+                .then((userRes) => {
+                    expect(userRes.body.scopes).to.deep.equal(['']);
+                    return;
+                })
+        );
     });
 });

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -237,16 +237,26 @@ describe('User API:', () => {
             request(app)
                 .put(`${baseURL}/user/scopes/${userId}`)
                 .set('Authorization', jwtToken)
-                .send({
-                    scopes: ['newScope'],
-                })
+                .send({ scopes: ['newScope'] })
                 .expect(httpStatus.OK)
                 .then(() => request(app)
-                        .get(`${baseURL}/user/${userId}`)
-                        .then((userRes) => {
-                            expect(userRes.body.scopes).to.deep.equal(['newScope']);
-                            return;
-                        }))
+                    .get(`${baseURL}/user/${userId}`)
+                    .then((userRes) => {
+                        expect(userRes.body.scopes).to.deep.equal(['newScope']);
+                        return;
+                    }))
+        );
+
+        it('should return the new information of the changed user', () =>
+            request(app)
+                .put(`${baseURL}/user/scopes/${userId}`)
+                .set('Authorization', jwtToken)
+                .send({ scopes: ['newScope'] })
+                .expect(httpStatus.OK)
+                .then((userRes) => {
+                    expect(userRes.body.scopes).to.deep.equal(['newScope']);
+                    return;
+                })
         );
 
         it('should work with an empty array update', () =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1773,6 +1773,13 @@ expect-ct@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/expect-ct/-/expect-ct-0.1.0.tgz#52735678de18530890d8d7b95f0ac63640958094"
 
+express-jwt-permissions@false1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/express-jwt-permissions/-/express-jwt-permissions-1.0.0.tgz#ed6171d06f662dfa58f3a7707b7d2c8e37583a7d"
+  dependencies:
+    lodash.get "^4.4.2"
+    xtend "^4.0.1"
+
 express-jwt@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-5.3.0.tgz#3d90cd65802e6336252f19e6a3df3e149e0c5ea0"
@@ -3332,6 +3339,10 @@ lodash.find@^4.3.0:
 lodash.findindex@^4.3.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.findindex/-/lodash.findindex-4.6.0.tgz#a3245dee61fb9b6e0624b535125624bb69c11106"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
#### What's this PR do?
Allows users to create OAuth-style scope arrays for permissions embedded in JWT. Sets up middleware for the microservice to validate admin functionality, which serves as an example of how to validate scopes in other services.

#### Related JIRA tickets:
SER-10, SER-43

#### How should this be manually tested?
Create a user with `admin` scope. Make sure this user can update user scopes, as this is an admin-protected function. The workflow is demonstrated in the test code.