### PR TITLE
hide password and salt in API responses

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -27,7 +27,7 @@ function load(req, res, next, id) {
  * Returns JSON of the specified user
  */
 function get(req, res) {
-    return res.json(req.user);
+    return res.json(req.user.getBasicUserInfo());
 }
 
 /**
@@ -44,7 +44,7 @@ function create(req, res, next) {
     });
 
     user.save()
-        .then(savedUser => res.json(savedUser))
+        .then(savedUser => res.json(savedUser.getBasicUserInfo()))
         .catch(e => next(e));
 }
 
@@ -58,7 +58,7 @@ function update() {}
 function updateScopes(req, res, next) {
     User.findById(req.params.userId)
         .then(user => user.update({ scopes: req.body.scopes }))
-        .then(updatedUser => res.json(updatedUser))
+        .then(updatedUser => res.json(updatedUser.getBasicUserInfo()))
         .catch(e => next(e));
 }
 

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -102,6 +102,15 @@ module.exports = (sequelize, DataTypes) => {
     };
 
     // Instance methods
+    User.prototype.getBasicUserInfo = function getBasicUserInfo() {
+        return {
+            id: this.id,
+            username: this.username,
+            email: this.email,
+            scopes: this.scopes,
+        };
+    };
+
     User.prototype.updatePassword = function updatePassword() {
         this.salt = uuid.v4();
         this.password = crypto.pbkdf2Sync(this.password, Buffer.from(this.salt), 100000, 128, 'sha256').toString('hex');

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -150,7 +150,7 @@ describe('User API:', () => {
                 .catch(done);
         });
 
-        xit('should return only necessary User information', (done) => {
+        it('should return only necessary User information', (done) => {
             request(app)
                 .post(`${baseURL}/user`)
                 .send(user)

--- a/server/tests/models/user.model.spec.js
+++ b/server/tests/models/user.model.spec.js
@@ -15,6 +15,7 @@ const testUser = {
     username: 'KK123',
     email: 'test@amida.com',
     password: 'testpass',
+    scopes: ['test'],
 };
 
 const expTime = 3600;
@@ -69,6 +70,22 @@ describe('User models:', () => {
                     return user.save()
                         .then(() => user.reload)
                         .then(() => expect(user.password).to.equal(firstPass));
+                })
+        );
+    });
+
+    describe('getBasicUserInfo', () => {
+        it('should return only the fields necessary for a client', () =>
+            User.create(testUser)
+                .then((user) => {
+                    const userInfo = user.getBasicUserInfo();
+                    expect(userInfo.id).to.exist;
+                    expect(userInfo.username).to.equal(testUser.username);
+                    expect(userInfo.email).to.equal(testUser.email);
+                    expect(userInfo.scopes).to.deep.equal(testUser.scopes);
+                    expect(userInfo.password).to.not.exist;
+                    expect(userInfo.salt).to.not.exist;
+                    return;
                 })
         );
     });


### PR DESCRIPTION
#### What's this PR do?
Remove password and salt in API responses. This is unnecessary and presents a security risk.

#### Related JIRA tickets:
SER-67

#### How should this be manually tested?
Perform any `/user` API call. Confirm that only id, username, email, and scopes are present on the response object.