### PR TITLE
add user update and isAdmin checks

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -48,7 +48,19 @@ function create(req, res, next) {
         .catch(e => next(e));
 }
 
-function update() {}
+function update(req, res, next) {
+    User.findById(req.params.userId)
+        .then((user) => {
+            if (req.user.username !== user.username && !req.user.isAdmin()) {
+                const e = new Error('User not allowed to update email');
+                e.status = httpStatus.FORBIDDEN;
+                return next(e);
+            }
+            return user.update({ email: req.body.email });
+        })
+        .then(updatedUser => res.json(updatedUser))
+        .catch(e => next(e));
+}
 
 /**
  * Update authorization scopes for a given user.

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -49,8 +49,7 @@ module.exports = (sequelize, DataTypes) => {
         },
         scopes: {
             type: DataTypes.ARRAY(DataTypes.STRING),
-            allowNull: true,
-            default: [''],
+            defaultValue: [''],
         },
         resetToken: {
             type: DataTypes.STRING,
@@ -102,6 +101,10 @@ module.exports = (sequelize, DataTypes) => {
     };
 
     // Instance methods
+    User.prototype.isAdmin = function isAdmin() {
+        return this.scopes.includes('admin');
+    };
+
     User.prototype.updatePassword = function updatePassword() {
         this.salt = uuid.v4();
         this.password = crypto.pbkdf2Sync(this.password, Buffer.from(this.salt), 100000, 128, 'sha256').toString('hex');

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -20,7 +20,9 @@ router.route('/:userId')
     .get(userCtrl.get)
 
     /** PUT /api/users/:userId - Update user */
-    .put(validate(userValidation.updateUser), userCtrl.update)
+    .put(validate(userValidation.updateUser),
+         passport.authenticate('jwt', { session: false }),
+         userCtrl.update)
 
     /** DELETE /api/users/:userId - Delete user */
     .delete(userCtrl.remove);
@@ -35,7 +37,8 @@ router.route('/scopes/:userId')
 router.route('/me')
     .get(userCtrl.me);
 
-/** Load user when API with userId route parameter is hit */
+// Load user when API with userId route parameter is hit
+// NOTE: this will be overwritten by the JWT user on protected routes
 router.param('userId', userCtrl.load);
 
 export default router;

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -164,7 +164,90 @@ describe('User API:', () => {
         });
     });
 
-    describe(('PUT /api/user/scopes/:userId'), () => {
+    describe('PUT /api/user/:userId', () => {
+        let userId;
+        let adminUserId;
+        let jwtToken;
+        let adminJwtToken;
+
+        beforeEach(() => request(app)
+            .post(`${baseURL}/user`)
+            .send(adminUser)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                adminUserId = res.body.id;
+                return;
+            })
+        );
+
+        beforeEach(() => request(app)
+            .post(`${baseURL}/user`)
+            .send(user)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                userId = res.body.id;
+                return;
+            })
+        );
+
+        beforeEach(() => request(app)
+            .post(`${baseURL}/auth/login`)
+            .send(userCredentials)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.have.property('token');
+                jwtToken = `Bearer ${res.body.token}`;
+                return;
+            })
+        );
+
+        beforeEach(() => request(app)
+            .post(`${baseURL}/auth/login`)
+            .send(adminUserCredentials)
+            .expect(httpStatus.OK)
+            .then((res) => {
+                expect(res.body).to.have.property('token');
+                adminJwtToken = `Bearer ${res.body.token}`;
+                return;
+            })
+        );
+
+        it('should update a user\'s email', () =>
+            request(app)
+                .put(`${baseURL}/user/${userId}`)
+                .set('Authorization', jwtToken)
+                .send({ email: 'newemail@email.com' })
+                .expect(httpStatus.OK)
+                .then((res) => {
+                    expect(res.body.username).to.equal('KK123');
+                    expect(res.body.email).to.equal('newemail@email.com');
+                    return;
+                })
+        );
+
+        it('should allow admins to update another user\'s email', () =>
+            request(app)
+                .put(`${baseURL}/user/${userId}`)
+                .set('Authorization', adminJwtToken)
+                .send({ email: 'newemail@email.com' })
+                .expect(httpStatus.OK)
+                .then((res) => {
+                    expect(res.body.username).to.equal('KK123');
+                    expect(res.body.email).to.equal('newemail@email.com');
+                    return;
+                })
+        );
+
+        it('should forbid users from updating another user\'s email', () => {
+            request(app)
+                .put(`${baseURL}/user/${adminUserId}`)
+                .set('Authorization', jwtToken)
+                .send({ email: 'newemail' })
+                .expect(httpStatus.FORBIDDEN);
+        });
+    });
+
+    describe('PUT /api/user/scopes/:userId', () => {
         let userId;
         let jwtToken;
 

--- a/server/tests/models/user.model.spec.js
+++ b/server/tests/models/user.model.spec.js
@@ -17,6 +17,13 @@ const testUser = {
     password: 'testpass',
 };
 
+const adminUser = {
+    username: 'KK123',
+    email: 'test@amida.com',
+    password: 'testpass',
+    scopes: ['admin'],
+};
+
 const expTime = 3600;
 
 describe('User models:', () => {
@@ -46,6 +53,16 @@ describe('User models:', () => {
             .then((users) => {
                 expect(users).to.have.lengthOf(0);
             }));
+    });
+
+    describe('isAdmin', () => {
+        it('should return true if the user instance has admin scope', () => User.create(adminUser)
+            .then(user => expect(user.isAdmin()).to.be.true)
+        );
+
+        it('should return false if the user instance does not have admin scope', () => User.create(testUser)
+            .then(user => expect(user.isAdmin()).to.be.false)
+        );
     });
 
     // describe('beforeCreate');


### PR DESCRIPTION
#### What's this PR do?
- user updates require either yourself or admin to be logged in

#### Related JIRA tickets:
SER-51

#### How should this be manually tested?
Create a user and an admin user. Log in as the non-admin user. You should be able to PUT to update your own email. Try to update the admin user's email. It should fail. Not log in as the admin user. You should be able to update the email of both users.