### PR TITLE
JWT Public Key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ PORT=4000
 JWT_MODE=rsa
 JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
 JWT_PRIVATE_KEY_PATH=private.key
+JWT_PUBLIC_KEY_PATH=private.key.pub
 
 PG_DB=api
 PG_PORT=5432

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
 NODE_ENV=development
 PORT=4000
 
+JWT_MODE=rsa
 JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
+JWT_PRIVATE_KEY_PATH=private.key
 
 PG_DB=api
 PG_PORT=5432

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ node_modules
 
 # .env
 .env
+
+# keys
+*.key
+*.pub

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,16 @@ WORKDIR /app
 
 # only copy package.json initially so that `RUN yarn` layer is recreated only
 # if there are changes in package.json
-ADD package.json yarn.lock /app/
+ADD . /app/
+RUN yarn
 
-# --pure-lockfile: Don’t generate a yarn.lock lockfile
-RUN yarn --pure-lockfile
+# compile to ES5
+RUN yarn build
 
-# copy all file from current dir to /app in container
-COPY . /app/
+COPY .env.example dist/.env
 
 # expose port 4000
 EXPOSE 4000
 
 # cmd to start service
-CMD [ "yarn", "start" ]
+CMD [ "node", "dist/index.js" ]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ For example, one API endpoint could allow _any_ authenticated user to view certa
 #### Roles
 In order to support fine-grained permissions, the User model contains a `scopes` field. This is an array of arbitrary strings meant to indicate roles and permissions for a User. Within the auth service, the only significant scope is `admin`. Other scopes may be added and used as necessary.
 
+#### Signing algorithm
+By default, the auth service signs JWTs with HMAC. This relies on a shared secret between the auth service and the consuming service. Whenever possible, you should use the RSA implementation. This can be activated by setting JWT_MODE='rsa' and setting the JWT_PRIVATE_KEY_PATH to the location of a private key. The public key should be available for the consuming service in order to verify the JWTs, and the auth service should locate the public key via JWT_PUBLIC_KEY_PATH.
+
+To generate a keypair:
+ssh-keygen -t rsa -b 4096 -f private.key
+openssl rsa -in private.key -pubout -outform PEM -out private.key.pub
+
 ### API Spec
 Apiary docs can be found at http://docs.amidaauth.apiary.io/.
 

--- a/config/config.js
+++ b/config/config.js
@@ -16,6 +16,8 @@ const envVarsSchema = Joi.object({
         .description('JWT Secret required to sign'),
     JWT_PRIVATE_KEY_PATH: Joi.string()
         .description('Absolute or relative path to RSA private key'),
+    JWT_PUBLIC_KEY_PATH: Joi.string()
+        .description('Absolute or relative path to RSA public key'),
     PG_DB: Joi.string().required()
         .description('Postgres database name'),
     PG_PORT: Joi.number()
@@ -85,6 +87,7 @@ const config = {
     jwtMode: envVars.JWT_MODE,
     jwtSecret: envVars.JWT_SECRET,
     jwtPrivateKeyPath: envVars.JWT_PRIVATE_KEY_PATH,
+    jwtPublicKeyPath: envVars.JWT_PUBLIC_KEY_PATH,
     postgres: {
         db: envVars.PG_DB,
         port: envVars.PG_PORT,

--- a/config/config.js
+++ b/config/config.js
@@ -10,8 +10,12 @@ const envVarsSchema = Joi.object({
         .default('development'),
     PORT: Joi.number()
         .default(4000),
-    JWT_SECRET: Joi.string().required()
+    JWT_MODE: Joi.string().allow(['rsa', 'hmac']).default('hmac')
+        .description('Signing algorithm for JWT'),
+    JWT_SECRET: Joi.string()
         .description('JWT Secret required to sign'),
+    JWT_PRIVATE_KEY_PATH: Joi.string()
+        .description('Absolute or relative path to RSA private key'),
     PG_DB: Joi.string().required()
         .description('Postgres database name'),
     PG_PORT: Joi.number()
@@ -78,7 +82,9 @@ if (error) {
 const config = {
     env: envVars.NODE_ENV,
     port: envVars.PORT,
+    jwtMode: envVars.JWT_MODE,
     jwtSecret: envVars.JWT_SECRET,
+    jwtPrivateKeyPath: envVars.JWT_PRIVATE_KEY_PATH,
     postgres: {
         db: envVars.PG_DB,
         port: envVars.PG_PORT,

--- a/config/passport.js
+++ b/config/passport.js
@@ -2,12 +2,20 @@ import {
     Strategy as JwtStrategy,
     ExtractJwt,
 } from 'passport-jwt';
+import fs from 'fs';
 import { User } from './sequelize';
 import config from './config';
 
+var key;
+if (config.jwtMode === 'rsa') {
+    key = fs.readFileSync(config.jwtPublicKeyPath);
+} else {
+    key = config.jwtSecret;
+}
+
 const opts = {
     jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-    secretOrKey: config.jwtSecret,
+    secretOrKey: key,
 };
 
 module.exports = (passport) => {

--- a/config/passport.js
+++ b/config/passport.js
@@ -6,7 +6,7 @@ import fs from 'fs';
 import { User } from './sequelize';
 import config from './config';
 
-var key;
+let key;
 if (config.jwtMode === 'rsa') {
     key = fs.readFileSync(config.jwtPublicKeyPath);
 } else {

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -103,8 +103,8 @@ module.exports = (sequelize, DataTypes) => {
     // Instance methods
     User.prototype.isAdmin = function isAdmin() {
         return this.scopes.includes('admin');
-    }
-    
+    };
+
     User.prototype.getBasicUserInfo = function getBasicUserInfo() {
         return {
             id: this.id,

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -2,6 +2,7 @@
 /* eslint no-unused-expressions: 0 */
 
 import request from 'supertest';
+import fs from 'fs';
 import httpStatus from 'http-status';
 import jwt from 'jsonwebtoken';
 import chai, { expect } from 'chai';
@@ -78,7 +79,13 @@ describe('Auth API:', () => {
                 .expect(httpStatus.OK)
                 .then((res) => {
                     expect(res.body).to.have.property('token');
-                    const decoded = jwt.verify(res.body.token, config.jwtSecret);
+                    let decoded;
+                    if (config.jwtMode === 'rsa') {
+                        const cert = fs.readFileSync(config.jwtPublicKeyPath);
+                        decoded = jwt.verify(res.body.token, cert);
+                    } else {
+                        decoded = jwt.verify(res.body.token, config.jwtSecret);
+                    }
                     expect(decoded.username).to.equal(validUserCredentials.username);
                     expect(decoded.email).to.equal(testUser.email);
                     expect(decoded.scopes).to.deep.equal(testUser.scopes);
@@ -104,7 +111,13 @@ describe('Auth API:', () => {
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.have.property('token');
-                const decoded = jwt.verify(res.body.token, config.jwtSecret);
+                let decoded;
+                if (config.jwtMode === 'rsa') {
+                    const cert = fs.readFileSync(config.jwtPublicKeyPath);
+                    decoded = jwt.verify(res.body.token, cert);
+                } else {
+                    decoded = jwt.verify(res.body.token, config.jwtSecret);
+                }
                 expect(decoded.username).to.equal(validUserCredentials.username);
                 jwtToken = `Bearer ${res.body.token}`;
             })
@@ -184,7 +197,13 @@ describe('Auth API:', () => {
             .expect(httpStatus.OK)
             .then((res) => {
                 expect(res.body).to.have.property('token');
-                const decoded = jwt.verify(res.body.token, config.jwtSecret);
+                let decoded;
+                if (config.jwtMode === 'rsa') {
+                    const cert = fs.readFileSync(config.jwtPublicKeyPath);
+                    decoded = jwt.verify(res.body.token, cert);
+                } else {
+                    decoded = jwt.verify(res.body.token, config.jwtSecret);
+                }
                 expect(decoded.username).to.equal(validUserCredentials.username);
                 jwtToken = `Bearer ${res.body.token}`;
                 return;

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -87,8 +87,6 @@ describe('Auth API:', () => {
         );
     });
 
-    // TODO describe('# POST /auth/logout');
-
     describe('POST /auth/reset-password', () => {
         let resetToken;
 


### PR DESCRIPTION
#### What's this PR do?
Allow JWT signing and verification with RSA, rather than HMAC.

#### Related JIRA tickets:
SER-66

#### How should this be manually tested?
First, set JWT_MODE to `rsa` in `.env`. Then, generate a keypair according to the README. You should be able to run the API manually, as well as run the test harness. Make sure the public/private key path variables are set to match whatever keys you create.

Additionally, if you have a service that integrates with the auth service, you can now set the `.verify` function calls to use the `RS256` algorithm and use the public key in place of the shared secret. See `config/passport.js` to see how the auth service does it internally.