### PR TITLE
Feature/delete and restrict users

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -28,14 +28,25 @@ function load(req, res, next, id) {
 }
 
 /**
- * Get user
- * Sends back JSON of the specified user
+ * Get info on a single user.
+ * Must be admin, or the specified user.
+ * Sends back JSON of the specified user.
  * @param req
  * @param res
+ * @param next
  * @returns {*}
  */
-function get(req, res) {
-    return res.json(req.user.getBasicUserInfo());
+function get(req, res, next) {
+    User.findById(req.params.userId)
+        .then((user) => {
+            if (req.user.username !== user.username && !req.user.isAdmin()) {
+                const e = new Error('Cannot get another user\s information');
+                e.status = httpStatus.FORBIDDEN;
+                return next(e);
+            }
+            return res.json(user.getBasicUserInfo());
+        })
+        .catch(e => next(e));
 }
 
 /**
@@ -90,6 +101,15 @@ function updateScopes(req, res, next) {
         .catch(e => next(e));
 }
 
+/**
+ * Get a full list of users.
+ * Restricted to admin.
+ * Sends back JSON of the updated user.
+ * @param req
+ * @param res
+ * @param next
+ * @returns {*}
+ */
 function list() {}
 
 /**

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -92,9 +92,32 @@ function updateScopes(req, res, next) {
 
 function list() {}
 
-function remove() {}
+/**
+ * Deletes a user.
+ * Restricted to admin.
+ * Sends back a 204.
+ * @param req
+ * @param res
+ * @param next
+ * @returns {*}
+ */
+function remove(req, res, next) {
+    User.findById(req.params.userId)
+        .then(user => user.destroy())
+        .then(() => res.sendStatus(204))
+        .catch(e => next(e));
+}
 
-function me() {}
+/**
+ * Assumes req.user has been loaded by the JWT middleware.
+ * Sends back JSON of the logged-in user.
+ * @param req
+ * @param res
+ * @returns {*}
+ */
+function me(req, res) {
+    return res.json(req.user.getBasicUserInfo());
+}
 
 export default {
     load,

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -40,7 +40,7 @@ function get(req, res, next) {
     User.findById(req.params.userId)
         .then((user) => {
             if (req.user.username !== user.username && !req.user.isAdmin()) {
-                const e = new Error('Cannot get another user\s information');
+                const e = new Error('Cannot get another user\'s information');
                 e.status = httpStatus.FORBIDDEN;
                 return next(e);
             }

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -15,6 +15,10 @@ router.route('/')
     /** POST /api/users - Create new user */
     .post(validate(userValidation.createUser), userCtrl.create);
 
+router.route('/me')
+    .get(passport.authenticate('jwt', { session: false }),
+         userCtrl.me);
+
 router.route('/:userId')
     /** GET /api/users/:userId - Get user */
     .get(userCtrl.get)
@@ -25,7 +29,9 @@ router.route('/:userId')
          userCtrl.update)
 
     /** DELETE /api/users/:userId - Delete user */
-    .delete(userCtrl.remove);
+    .delete(passport.authenticate('jwt', { session: false }),
+            permissions.check('admin'),
+            userCtrl.remove);
 
 router.route('/scopes/:userId')
     /** PUT /api/user/scopes/:userId - Update user scopes */
@@ -33,9 +39,6 @@ router.route('/scopes/:userId')
          passport.authenticate('jwt', { session: false }),
          permissions.check('admin'),
          userCtrl.updateScopes);
-
-router.route('/me')
-    .get(userCtrl.me);
 
 // Load user when API with userId route parameter is hit
 // NOTE: this will be overwritten by the JWT user on protected routes

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -10,7 +10,9 @@ const permissions = guard({ permissionsProperty: 'scopes' });
 
 router.route('/')
     /** GET /api/users - Get list of users */
-    .get(userCtrl.list)
+    .get(passport.authenticate('jwt', { session: false }),
+         permissions.check('admin'),
+         userCtrl.list)
 
     /** POST /api/users - Create new user */
     .post(validate(userValidation.createUser), userCtrl.create);
@@ -21,7 +23,8 @@ router.route('/me')
 
 router.route('/:userId')
     /** GET /api/users/:userId - Get user */
-    .get(userCtrl.get)
+    .get(passport.authenticate('jwt', { session: false }),
+         userCtrl.get)
 
     /** PUT /api/users/:userId - Update user */
     .put(validate(userValidation.updateUser),

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -367,6 +367,7 @@ describe('User API:', () => {
                 .expect(httpStatus.OK)
                 .then(() => request(app)
                     .get(`${baseURL}/user/${userId}`)
+                    .set('Authorization', jwtToken)
                     .then((userRes) => {
                         expect(userRes.body.scopes).to.deep.equal(['newScope']);
                         return;


### PR DESCRIPTION
#### What's this PR do?
- Allow admins to delete users
- Give logged-in users a route to get their basic information
- Insure existing routes are properly protected, although not all routes are fully tested
#### Related JIRA tickets:
- SER-9
- SER-50
#### How should this be manually tested?
1. Create a regular user and an admin user
2. Try to delete the admin user with the regular user. This should fail.
3. Both users should be able to get their personal info on the `/api/user/me` route.
4. The admin user should be able to delete the regular user.
5. The regular user's JWT should no longer work once the user is deleted.