### PR TITLE
add README instructions for generating a test token

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ gulp clean
 gulp
 ```
 
+### Unit testing against auth
+To make it easier to unit test against the auth service, you can generate dummy tokens by going to jwt.io. You should enter, at minimum, the following information:
+
+Header:
+```
+{
+  "alg": "HS256",
+  "typ": "JWT"
+}
+```
+
+Payload:
+```
+{
+  "id": <userId>,
+  "username": <username>,
+  "email": <email>,
+  "scopes": [""]
+}
+```
+If you need an admin token, enter `"admin"` in the scopes array.
+
+Then, in the "Verify Signature" section, enter the shared secret used by the app you are authenticating for.
+
+
 ## Deployment
 
 ### Manual deployment with `pm2`


### PR DESCRIPTION
#### What's this PR do?
Add instructions to the README for creating sample JWTs. In some cases, a developer may want to test another service that will eventually authenticate against the Amida Auth service, but without actually using an instance of the Auth service. We provide directions for using jwt.io to create dummy tokens to the requirements of the Auth service.

#### Related JIRA tickets:
SER-73

#### How should this be manually tested?
Select a secondary service, such as messaging or surveys. Create a token by following the instructions in the README. Make sure that the appropriate protected routes can be accessed in unit tests using this token.

#### Any background context you want to provide?
#### Screenshots (if appropriate):