### PR TITLE
app doesn't crash when started without facebook env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ openssl rsa -in private.key -pubout -outform PEM -out private.key.pub
 Apiary docs can be found at http://docs.amidaauth.apiary.io/.
 
 ### External auth
+The Amida Auth service can allow external OAuth providers to manage identity. If a user is created via external auth, they will still get an entry in the Users database. However, they will not get a password, and password management functions will be disabled for that user. The `provider` column will contain an identifier for the OAuth provider managing that user.
+
+To specify the external auth used for an instance of the service, use the `*_CLIENT_ID` env vars. Allowed strategies are shown in `config/config.js`.
+
 #### Facebook
 To set up integration with Facebook, configure your domain for the auth service as a Facebook Login product with `<domain>/api/vX/auth/facebook/callback` as a redirect URL, then set the following env vars:
 ```

--- a/config/passport.js
+++ b/config/passport.js
@@ -30,23 +30,25 @@ module.exports = (passport) => {
             .catch(err => done(err, false));
     }));
 
-    passport.use(new FacebookStrategy({
-        clientID: config.facebook.clientId,
-        clientSecret: config.facebook.clientSecret,
-        callbackURL: config.facebook.callbackUrl,
-        profileFields: ['email'],
-    }, (accessToken, refreshToken, profile, done) => {
-        const email = profile.emails[0].value;
-        User.findOrCreate({ where: {
-            username: email,
-            email,
-            provider: profile.provider,
-        } })
-        .spread((user) => {
-            if (user !== null) return done(null, user);
-            const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
-            return done(err);
-        });
-    }));
+    if (config.facebook.clientId) {
+        passport.use(new FacebookStrategy({
+            clientID: config.facebook.clientId,
+            clientSecret: config.facebook.clientSecret,
+            callbackURL: config.facebook.callbackUrl,
+            profileFields: ['email'],
+        }, (accessToken, refreshToken, profile, done) => {
+            const email = profile.emails[0].value;
+            User.findOrCreate({ where: {
+                username: email,
+                email,
+                provider: profile.provider,
+            } })
+            .spread((user) => {
+                if (user !== null) return done(null, user);
+                const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
+                return done(err);
+            });
+        }));
+    }
 };
 


### PR DESCRIPTION
#### What's this PR do?
If you start your app without the `FACEBOOK_*` env vars, it won't crash. It's now clear from implementation how to add a new external provider strategy without breaking env compatibility.