### PR TITLE
Feature/ser 81 lock user creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 NODE_ENV=development
 PORT=4000
+CREATE_USER_ADMIN=false
 
 JWT_MODE=hmac
 JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ ssh-keygen -t rsa -b 4096 -f private.key
 openssl rsa -in private.key -pubout -outform PEM -out private.key.pub
 ```
 
+### Seeding
+Since many operations require an admin user, you may find it easiest to begin using the service with a default admin user, to be removed later.
+To create this user, simply run `yarn seed`.
+
 ### API Spec
 Apiary docs can be found at http://docs.amidaauth.apiary.io/.
 

--- a/config/config.js
+++ b/config/config.js
@@ -10,6 +10,8 @@ const envVarsSchema = Joi.object({
         .default('development'),
     PORT: Joi.number()
         .default(4000),
+    CREATE_USER_ADMIN: Joi.bool()
+        .default(true),
     JWT_MODE: Joi.string().allow(['rsa', 'hmac']).default('hmac')
         .description('Signing algorithm for JWT'),
     JWT_SECRET: Joi.string()
@@ -89,6 +91,7 @@ if (error) {
 const config = {
     env: envVars.NODE_ENV,
     port: envVars.PORT,
+    createUserAdmin: envVars.CREATE_USER_ADMIN,
     jwtMode: envVars.JWT_MODE,
     jwtSecret: envVars.JWT_SECRET,
     jwtPrivateKeyPath: envVars.JWT_PRIVATE_KEY_PATH,

--- a/config/seed.js
+++ b/config/seed.js
@@ -1,0 +1,32 @@
+/**
+ * Populate DB with sample data on server start
+ * to disable, edit config/environment/index.js, and set `seedDB: false`
+ */
+
+import {
+    User,
+    sequelize,
+} from './sequelize';
+
+const debug = require('debug')('amida-auth-microservice:seed');
+
+const adminUser = {
+    username: 'admin',
+    email: 'admin@default.com',
+    password: 'admin',
+    scopes: ['admin'],
+};
+
+User.sync({ pool: false })
+    .then(() => sequelize.query('DELETE FROM "Users"', {
+        type: sequelize.QueryTypes.DELETE,
+    }))
+    .then(() => User.create(adminUser))
+    .then(() => {
+        debug('finished populating users');
+        process.exit(0);
+    })
+    .catch((err) => {
+        debug(err);
+        process.exit(1);
+    });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:check-coverage": "yarn test:coverage && istanbul check-coverage",
     "report-coverage": "coveralls < ./coverage/lcov.info",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "prepublish": "npm run snyk-protect",
+    "seed": "gulp; cross-env DEBUG=amida-auth-microservice:* node dist/config/seed.js; gulp clean"
   },
   "dependencies": {
     "bluebird": "3.4.6",

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -5,9 +5,18 @@ import passport from 'passport';
 import { userValidation } from '../../config/param-validation';
 import userCtrl from '../controllers/user.controller';
 import { checkExternalProvider } from '../helpers/jwt';
+import config from '../../config/config';
 
 const router = express.Router(); // eslint-disable-line new-cap
 const permissions = guard({ permissionsProperty: 'scopes' });
+
+let userAdminFunctions = [];
+if (config.createUserAdmin) {
+    userAdminFunctions = [
+        passport.authenticate('jwt', { session: false }),
+        permissions.check('admin'),
+    ];
+}
 
 router.route('/')
     /** GET /api/user - Get list of users */
@@ -17,8 +26,7 @@ router.route('/')
 
     /** POST /api/user - Create new user */
     .post(validate(userValidation.createUser),
-          passport.authenticate('jwt', { session: false }),
-          permissions.check('admin'),
+          ...userAdminFunctions,
           userCtrl.create);
 
 router.route('/me')

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -16,7 +16,10 @@ router.route('/')
          userCtrl.list)
 
     /** POST /api/user - Create new user */
-    .post(validate(userValidation.createUser), userCtrl.create);
+    .post(validate(userValidation.createUser),
+          passport.authenticate('jwt', { session: false }),
+          permissions.check('admin'),
+          userCtrl.create);
 
 router.route('/me')
     .get(passport.authenticate('jwt', { session: false }),

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -14,16 +14,24 @@ import * as common from './common.spec';
 chai.config.includeStack = true;
 
 describe('Auth API:', () => {
-    // before(() => sequelize.sync({
-    //     force: true,
-    // }));
+    before(() => sequelize.sync({
+        force: true,
+    }));
 
     after(() => User.destroy({ where: {} }));
 
+    let adminToken;
     let jwtToken;
 
     describe('POST /auth/login', () => {
-        before(() => common.setupTestUser(app));
+        before(() => common.seedAdminAndLogin(app)
+            .then((token) => {
+                adminToken = token;
+                return;
+            })
+        );
+
+        before(() => common.setupTestUser(app, adminToken));
 
         after(() => User.destroy({ where: {} }));
 
@@ -70,7 +78,14 @@ describe('Auth API:', () => {
     describe('POST /auth/reset-password', () => {
         let resetToken;
 
-        before(() => common.setupTestUser(app));
+        before(() => common.seedAdminAndLogin(app)
+            .then((token) => {
+                adminToken = token;
+                return;
+            })
+        );
+
+        before(() => common.setupTestUser(app, adminToken));
 
         after(() => User.destroy({ where: {} }));
 
@@ -153,7 +168,14 @@ describe('Auth API:', () => {
     });
 
     describe('POST /auth/update-password', () => {
-        before(() => common.setupTestUser(app));
+        before(() => common.seedAdminAndLogin(app)
+            .then((token) => {
+                adminToken = token;
+                return;
+            })
+        );
+
+        before(() => common.setupTestUser(app, adminToken));
 
         after(() => User.destroy({ where: {} }));
 


### PR DESCRIPTION
#### What's this PR do?
Prevents non-admin users from creating users.
Also includes a seed script and instructions for setting up the service with a bootstrap user.

#### Related JIRA tickets:
[SER-81](https://jira.amida-tech.com/browse/SER-81)

#### How should this be manually tested?
- Run the test harness
- Run the seed script and confirm a DB entry `yarn seed`