### PR TITLE
return 404 on missing email lookup

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -61,6 +61,11 @@ function get(req, res, next) {
 function getByEmail(req, res, next) {
     User.findOne({ where: { email: req.params.userEmail } })
         .then((user) => {
+            if (!user) {
+                const e = new Error('User does not exist');
+                e.status = httpStatus.NOT_FOUND;
+                return next(e);
+            }
             if (req.user.username !== user.username && !req.user.isAdmin()) {
                 const e = new Error('Cannot get another user\'s information');
                 e.status = httpStatus.FORBIDDEN;

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -166,6 +166,13 @@ describe('User API:', () => {
                     return;
                 })
         );
+
+        it('should return a 404 if the specified userEmail does not exist', () =>
+            request(app)
+                .get(`${common.baseURL}/user/byEmail/fake@email.com`)
+                .set('Authorization', jwtToken)
+                .expect(httpStatus.NOT_FOUND)
+        );
     });
 
     describe('GET /api/user/me', () => {


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
Missing email lookup now properly returns 404.