### PR TITLE
add OWASP password strength test

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -5,7 +5,7 @@ const userValidation = {
         body: {
             username: Joi.string().required(),
             email: Joi.string().email().required(),
-            password: Joi.string().min(8).max(64).required(),
+            password: Joi.string().required(),
         },
     },
     updateUser: {
@@ -23,7 +23,7 @@ const userValidation = {
 const authValidation = {
     updatePassword: {
         body: {
-            password: Joi.string().min(8).max(64).required(),
+            password: Joi.string().required(),
         },
     },
     resetToken: {
@@ -33,7 +33,7 @@ const authValidation = {
     },
     resetPassword: {
         body: {
-            password: Joi.string().min(8).max(64).required(),
+            password: Joi.string().required(),
         },
     },
     login: {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "moment": "2.19.3",
     "morgan": "1.9.0",
     "nodemailer": "4.1.0",
+    "owasp-password-strength-test": "1.3.0",
     "passport": "0.4.0",
     "passport-facebook": "2.1.1",
     "passport-jwt": "3.0.0",

--- a/server/helpers/owasp.js
+++ b/server/helpers/owasp.js
@@ -13,7 +13,7 @@ module.exports = {
     checkPassword(req, res, next) {
         const result = owasp.test(req.body.password);
         if (!result.strong) {
-            const err = new APIError(result.errors.join(), httpStatus.BAD_REQUEST, true);
+            const err = new APIError(result.errors.join('\r\n'), httpStatus.BAD_REQUEST, true);
             return next(err);
         }
         return next();

--- a/server/helpers/owasp.js
+++ b/server/helpers/owasp.js
@@ -1,0 +1,21 @@
+import httpStatus from 'http-status';
+import owasp from 'owasp-password-strength-test';
+import APIError from '../helpers/APIError';
+
+owasp.config({
+    allowPassphrases: true,
+    maxLength: 64,
+    minLength: 8,
+    minOptionalTestsToPass: 3,
+});
+
+module.exports = {
+    checkPassword(req, res, next) {
+        const result = owasp.test(req.body.password);
+        if (!result.strong) {
+            const err = new APIError(result.errors.join(), httpStatus.BAD_REQUEST, true);
+            return next(err);
+        }
+        return next();
+    },
+};

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -4,6 +4,7 @@ import passport from 'passport';
 import { authValidation } from '../../config/param-validation';
 import authCtrl from '../controllers/auth.controller';
 import { checkExternalProvider, signJWT } from '../helpers/jwt';
+import { checkPassword } from '../helpers/owasp';
 
 const router = express.Router(); // eslint-disable-line new-cap
 
@@ -13,7 +14,7 @@ router.route('/login')
 router.route('/logout');
 
 router.route('/update-password')
-    .post(validate(authValidation.updatePassword),
+    .post(validate(authValidation.updatePassword), checkPassword,
           passport.authenticate('jwt', { session: false }),
           checkExternalProvider,
           authCtrl.updatePassword);
@@ -23,7 +24,7 @@ router.route('/reset-password')
           authCtrl.resetToken);
 
 router.route('/reset-password/:token')
-    .post(validate(authValidation.resetPassword),
+    .post(validate(authValidation.resetPassword), checkPassword,
           authCtrl.resetPassword);
 
 router.route('/facebook')

--- a/server/routes/user.route.js
+++ b/server/routes/user.route.js
@@ -5,6 +5,7 @@ import passport from 'passport';
 import { userValidation } from '../../config/param-validation';
 import userCtrl from '../controllers/user.controller';
 import { checkExternalProvider } from '../helpers/jwt';
+import { checkPassword } from '../helpers/owasp';
 import config from '../../config/config';
 
 const router = express.Router(); // eslint-disable-line new-cap
@@ -27,7 +28,7 @@ router.route('/')
          userCtrl.list)
 
     /** POST /api/user - Create new user */
-    .post(validate(userValidation.createUser),
+    .post(validate(userValidation.createUser), checkPassword,
           ...userAdminFunctions,
           userCtrl.create);
 

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -218,7 +218,7 @@ describe('Auth API:', () => {
                 .set('Authorization', jwtToken)
                 .send({ password: 'badpass' })
                 .expect(httpStatus.BAD_REQUEST)
-                .then(res => expect(res.text).to.contain('length must be at least 8 characters long'))
+                .then(res => expect(res.text).to.contain('must be at least 8 characters long'))
         );
     });
 });

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -129,7 +129,7 @@ describe('Auth API:', () => {
                 .then((res1) => {
                     resetToken = res1.body.token;
                     return request(app).post(`${common.baseURL}/auth/reset-password/${resetToken}`)
-                        .send({ password: 'newerpass' })
+                        .send({ password: 'Newerpass123' })
                         .expect(httpStatus.OK)
                         .then(res2 => expect(res2.text).to.equal('OK'));
                 })
@@ -144,13 +144,13 @@ describe('Auth API:', () => {
                     resetToken = res1.body.token;
                     return request(app)
                         .post(`${common.baseURL}/auth/reset-password/${resetToken}`)
-                        .send({ password: 'newerpass' })
+                        .send({ password: 'Newerpass123' })
                         .expect(httpStatus.OK)
                         .then(() => request(app)
                                 .post(`${common.baseURL}/auth/login`)
                                 .send({
                                     username: 'KK123',
-                                    password: 'newerpass',
+                                    password: 'Newerpass123',
                                 })
                                 .expect(httpStatus.OK));
                 })
@@ -182,14 +182,14 @@ describe('Auth API:', () => {
             request(app)
                 .post(`${common.baseURL}/auth/update-password`)
                 .set('Authorization', jwtToken)
-                .send({ password: 'newerpass' })
+                .send({ password: 'Newerpass123' })
                 .expect(httpStatus.OK)
                 .then((res) => {
                     expect(res.text).to.equal('OK');
                     return request(app).post(`${common.baseURL}/auth/login`)
                         .send({
                             username: 'KK123',
-                            password: 'newerpass',
+                            password: 'Newerpass123',
                         })
                         .expect(httpStatus.OK);
                 })
@@ -198,7 +198,7 @@ describe('Auth API:', () => {
         it('should return 401 when user is not authenticated', () =>
             request(app)
                 .post(`${common.baseURL}/auth/update-password`)
-                .send({ password: 'newerpass' })
+                .send({ password: 'Newerpass123' })
                 .expect(httpStatus.UNAUTHORIZED)
                 .then(res => expect(res.text).to.equal('Unauthorized'))
         );
@@ -207,7 +207,7 @@ describe('Auth API:', () => {
             request(app)
                 .post(`${common.baseURL}/auth/update-password`)
                 .set('Authorization', 'Bearer BadJWT')
-                .send({ password: 'newerpass' })
+                .send({ password: 'Newerpass123' })
                 .expect(httpStatus.UNAUTHORIZED)
                 .then(res => expect(res.text).to.equal('Unauthorized'))
         );

--- a/server/tests/integration/common.spec.js
+++ b/server/tests/integration/common.spec.js
@@ -13,14 +13,14 @@ const baseURL = `/api/v${version}`;
 const adminUser = {
     username: 'amidaadmin',
     email: 'superadmin@amida.com',
-    password: 'adminpass',
+    password: 'Adminpass123',
     scopes: ['admin'],
 };
 
 const testUser = {
     username: 'KK123',
     email: 'test@amida.com',
-    password: 'testpass',
+    password: 'Testpass123',
     scopes: ['admin'],
 };
 
@@ -31,12 +31,12 @@ const badPassword = {
 
 const missingUsername = {
     username: 'missing',
-    password: 'testpass',
+    password: 'Testpass123',
 };
 
 const validUserCredentials = {
     username: 'KK123',
-    password: 'testpass',
+    password: 'Testpass123',
 };
 
 module.exports = {

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -256,7 +256,7 @@ describe('User API:', () => {
                 .send(userBadPassword)
                 .expect(httpStatus.BAD_REQUEST)
                 .then((res) => {
-                    expect(res.text).to.contain('length must be at least 8 characters long');
+                    expect(res.text).to.contain('must be at least 8 characters long');
                     done();
                 })
                 .catch(done);

--- a/server/tests/integration/user.integration.spec.js
+++ b/server/tests/integration/user.integration.spec.js
@@ -19,12 +19,12 @@ describe('User API:', () => {
     const testUser = {
         username: 'KK123',
         email: 'test@amida.com',
-        password: 'testpass',
+        password: 'Testpass123',
     };
 
     const testUserCredentials = {
         username: 'KK123',
-        password: 'testpass',
+        password: 'Testpass123',
     };
 
     const userBadPassword = {
@@ -42,25 +42,25 @@ describe('User API:', () => {
     const userDuplicateUsername = {
         username: 'KK123',
         email: 'test2@amida.com',
-        password: 'testpass',
+        password: 'Testpass123',
     };
 
     const userDuplicateEmail = {
         username: 'KK1234',
         email: 'test@amida.com',
-        password: 'testpass',
+        password: 'Testpass123',
     };
 
     const adminUser = {
         username: 'admin',
         email: 'admin@amida.com',
-        password: 'adminpass',
+        password: 'Adminpass123',
         scopes: ['admin'],
     };
 
     const adminUserCredentials = {
         username: 'admin',
-        password: 'adminpass',
+        password: 'Adminpass123',
     };
 
     let adminToken;
@@ -217,6 +217,23 @@ describe('User API:', () => {
     });
 
     describe('POST /api/user', () => {
+        it('should reject a bad password and return error info', () => request(app)
+            .post(`${common.baseURL}/user`)
+            .set('Authorization', `Bearer ${adminToken}`)
+            .send({
+                username: 'KK123',
+                email: 'test@amida.com',
+                password: 'badpassword',
+            })
+            .expect(httpStatus.BAD_REQUEST)
+            .then((res) => {
+                expect(res.text).to.contain('must contain at least one uppercase letter');
+                expect(res.text).to.contain('must contain at least one number');
+                expect(res.text).to.contain('must contain at least one special character');
+                return;
+            })
+        );
+
         it('should create a new user and return it without password info', (done) => {
             request(app)
                 .post(`${common.baseURL}/user`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,6 +4011,10 @@ output-file-sync@^1.1.0:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
+owasp-password-strength-test@false1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/owasp-password-strength-test/-/owasp-password-strength-test-1.3.0.tgz#4f629e42903e8f6d279b230d657ab61e58e44b12"
+
 package-json@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-1.2.0.tgz#c8ecac094227cdf76a316874ed05e27cc939a0e0"


### PR DESCRIPTION
#### What's this PR do?
Adds OWASP password validation to all password-related routes. The checking is done by a middleware function before controllers are called.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/RR-808

#### How should this be manually tested?
Create a new user, update a password, and reset a password. In all of these stages, passwords must meet OWASP standards.

#### Any background context you want to provide?
Middleware is configured to enforce 2/3 of: uppercase, number, and special character.