### PR TITLE
SER-174 Use requesting origin for reset password links in email

### DIFF
--- a/server/helpers/mailer.js
+++ b/server/helpers/mailer.js
@@ -33,8 +33,7 @@ module.exports = {
     },
 
     generateLink(req, token) {
-        return util.format('http://%s/reset-password/%s', req.headers.host, token);
+        return util.format('%s/reset-password/%s', req.headers.origin, token);
     },
 
 };
-


### PR DESCRIPTION
#### What's this PR do?
Constructs the url for the password-reset interface from the requester's origin.

This is a lightweight solution and does not check the origin against any environment variable or whitelist. I can think of an attack is if someone creates a spoof of a client site, manages to get a user on myfakeindaba.com and go through the forgot password flow with their client domain, and passes the password the users sets to their own backend as well. Or they can just post to `reset-password` with a known user's email and their spoof host in the origin header, and hope the user follows the link and resets and leaks their new password there.
If I'm right about that vulnerability, we may have to consider putting the client host in an environment variable, either just for the `reset-password` url, or for the CORS headers.

#### Related JIRA tickets:
[SER-174](https://jira.amida-tech.com/browse/SER-174)

#### How should this be manually tested?
1. Set valid smtp configuration in the .env file
1. Post to `/reset-password` with an origin header and a body like `{email: me@mymail.com}`
            `curl http://localhost:4000/api/v0/auth/reset-password -H "Origin: http://localhost:3000" -d email=me@gmail.com`
1. Check that a reset password is sent to that email with the original domain

#### Any background context you want to provide?
#### Screenshots (if appropriate):