### PR TITLE
add refresh token functionality

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -32,6 +32,11 @@ const authValidation = {
             refreshToken: Joi.string().required(),
         },
     },
+    refreshTokenReject: {
+        body: {
+            refreshToken: Joi.string().required(),
+        },
+    },
     resetToken: {
         body: {
             email: Joi.string().email().required(),

--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -26,6 +26,12 @@ const authValidation = {
             password: Joi.string().required(),
         },
     },
+    refreshToken: {
+        body: {
+            username: Joi.string().required(),
+            refreshToken: Joi.string().required(),
+        },
+    },
     resetToken: {
         body: {
             email: Joi.string().email().required(),

--- a/config/passport.js
+++ b/config/passport.js
@@ -24,31 +24,35 @@ const opts = {
 };
 
 module.exports = (passport) => {
-    passport.use(new JwtStrategy(opts, (jwtPayload, done) => {
+    const jwtStrategy = new JwtStrategy(opts, (jwtPayload, done) => {
         User.findOne({ where: { username: jwtPayload.username } })
             .then(user => done(null, user))
             .catch(err => done(err, false));
-    }));
+    });
+
+    const fbStrategy = new FacebookStrategy({
+        clientID: config.facebook.clientId,
+        clientSecret: config.facebook.clientSecret,
+        callbackURL: config.facebook.callbackUrl,
+        profileFields: ['email'],
+    }, (accessToken, refreshToken, profile, done) => {
+        const email = profile.emails[0].value;
+        User.findOrCreate({ where: {
+            username: email,
+            email,
+            provider: profile.provider,
+        } })
+        .spread((user) => {
+            if (user !== null) return done(null, user);
+            const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
+            return done(err);
+        });
+    });
+
+    passport.use(jwtStrategy);
 
     if (config.facebook.clientId) {
-        passport.use(new FacebookStrategy({
-            clientID: config.facebook.clientId,
-            clientSecret: config.facebook.clientSecret,
-            callbackURL: config.facebook.callbackUrl,
-            profileFields: ['email'],
-        }, (accessToken, refreshToken, profile, done) => {
-            const email = profile.emails[0].value;
-            User.findOrCreate({ where: {
-                username: email,
-                email,
-                provider: profile.provider,
-            } })
-            .spread((user) => {
-                if (user !== null) return done(null, user);
-                const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
-                return done(err);
-            });
-        }));
+        passport.use(fbStrategy);
     }
 };
 

--- a/config/passport.js
+++ b/config/passport.js
@@ -30,28 +30,28 @@ module.exports = (passport) => {
             .catch(err => done(err, false));
     });
 
-    const fbStrategy = new FacebookStrategy({
-        clientID: config.facebook.clientId,
-        clientSecret: config.facebook.clientSecret,
-        callbackURL: config.facebook.callbackUrl,
-        profileFields: ['email'],
-    }, (accessToken, refreshToken, profile, done) => {
-        const email = profile.emails[0].value;
-        User.findOrCreate({ where: {
-            username: email,
-            email,
-            provider: profile.provider,
-        } })
-        .spread((user) => {
-            if (user !== null) return done(null, user);
-            const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
-            return done(err);
-        });
-    });
-
     passport.use(jwtStrategy);
 
     if (config.facebook.clientId) {
+        const fbStrategy = new FacebookStrategy({
+            clientID: config.facebook.clientId,
+            clientSecret: config.facebook.clientSecret,
+            callbackURL: config.facebook.callbackUrl,
+            profileFields: ['email'],
+        }, (accessToken, refreshToken, profile, done) => {
+            const email = profile.emails[0].value;
+            User.findOrCreate({ where: {
+                username: email,
+                email,
+                provider: profile.provider,
+            } })
+            .spread((user) => {
+                if (user !== null) return done(null, user);
+                const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
+                return done(err);
+            });
+        });
+
         passport.use(fbStrategy);
     }
 };

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -25,6 +25,8 @@ const sequelize = new Sequelize(
 );
 
 db.User = sequelize.import('../server/models/user.model');
+db.RefreshToken = sequelize.import('../server/models/refreshToken.model');
+db.RefreshToken.belongsTo(db.User, { foreignKey: 'userId', targetKey: 'id' });
 
 // assign the sequelize variables to the db object and returning the db.
 module.exports = _.extend({

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "passport-jwt": "3.0.0",
     "pg": "6.1.6",
     "pg-hstore": "2.3.2",
+    "rand-token": "false0.4.0",
     "run-sequence": "^1.1.5",
     "sequelize": "^4.28.0",
     "snyk": "^1.40.0",

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -105,7 +105,6 @@ function rejectRefreshToken(req, res, next) {
     const params = _.pick(req.body, 'refreshToken');
     RefreshToken.findOne({ where: { token: params.refreshToken } })
     .then((tokenResult) => {
-        console.log(tokenResult);
         if (_.isNull(tokenResult)) {
             const err = new APIError('Refresh token not found', httpStatus.NOT_FOUND, true);
             return next(err);
@@ -115,10 +114,7 @@ function rejectRefreshToken(req, res, next) {
 
         return res.sendStatus(httpStatus.NO_CONTENT);
     })
-    .catch((error) => {
-        console.log(error);
-        return next(error);
-    });
+    .catch(error => next(error));
 }
 
 /**

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -86,15 +86,10 @@ function submitRefreshToken(req, res, next) {
         };
 
         const jwtToken = signJWT(userInfo);
-        const refreshToken = randtoken.uid(128);
-
-        // save the refresh token
-        userResult.update({ refreshToken });
 
         return res.json({
             token: jwtToken,
             username: userResult.username,
-            refreshToken,
         });
     })
     .catch(error => next(error));

--- a/server/models/refreshToken.model.js
+++ b/server/models/refreshToken.model.js
@@ -1,0 +1,31 @@
+/* eslint no-param-reassign: ["error", { "props": false }] */
+/* eslint new-cap: 0 */
+import randtoken from 'rand-token';
+
+/**
+ * User Schema
+ */
+module.exports = (sequelize, DataTypes) => {
+    const RefreshToken = sequelize.define('RefreshToken', {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        token: {
+            type: DataTypes.STRING,
+            unique: true,
+            allowNull: false,
+        },
+    });
+
+    RefreshToken.createNewToken = function createNewToken(userId) {
+        const refreshToken = randtoken.uid(128);
+        return this.create({
+            token: refreshToken,
+            userId,
+        });
+    };
+
+    return RefreshToken;
+};

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -57,6 +57,9 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.ARRAY(DataTypes.STRING),
             defaultValue: [''],
         },
+        refreshToken: {
+            type: DataTypes.STRING,
+        },
         resetToken: {
             type: DataTypes.STRING,
         },

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -14,7 +14,7 @@ router.route('/login')
 router.route('/logout');
 
 router.route('/token/reject')
-    .post(validate(authValidation.refreshToken), authCtrl.rejectRefreshToken);
+    .post(validate(authValidation.refreshTokenReject), authCtrl.rejectRefreshToken);
 
 router.route('/token')
     .post(validate(authValidation.refreshToken), authCtrl.submitRefreshToken);

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -13,6 +13,12 @@ router.route('/login')
 
 router.route('/logout');
 
+router.route('/token/reject')
+    .post(validate(authValidation.refreshToken), authCtrl.rejectRefreshToken);
+
+router.route('/token')
+    .post(validate(authValidation.refreshToken), authCtrl.submitRefreshToken);
+
 router.route('/update-password')
     .post(validate(authValidation.updatePassword), checkPassword,
           passport.authenticate('jwt', { session: false }),

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -122,7 +122,6 @@ describe('Auth API:', () => {
         it('should be able to expire refresh tokens', () => request(app)
             .post(`${common.baseURL}/auth/token/reject`)
             .send({
-                username: 'KK123',
                 refreshToken,
             })
             .expect(httpStatus.NO_CONTENT)

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -105,7 +105,6 @@ describe('Auth API:', () => {
                 expect(decoded.username).to.equal(common.validUserCredentials.username);
                 expect(decoded.email).to.equal(common.testUser.email);
                 expect(decoded.scopes).to.deep.equal(common.testUser.scopes);
-                refreshToken = res.body.refreshToken;
                 return;
             })
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4386,6 +4386,10 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+rand-token@false0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/rand-token/-/rand-token-0.4.0.tgz#1a565b6ad12d92dd4b30c4c4e5945e8aa24a5b3b"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"


### PR DESCRIPTION
#### What's this PR do?
Add refresh token endpoints and behavior.

#### Related JIRA tickets:
[SER-186](https://jira.amida-tech.com/browse/SER-186)

#### How should this be manually tested?
First, make sure the test harness runs.

Then, you will want to mimic the client workflow. Log in normally. You should set the normal auth token to have a short expiration time. When the token expires, confirm that you can use the reset token endpoint `POST /token` to get a new, valid JWT.

This behavior will be handled by clients. If they receive a 401 based on an expired token, they should call the `/token` endpoint then resubmit the 401. @mhiner can confirm that this is the correct design or correct me if I am wrong.

There is also an endpoint `POST /token/reject` that will expire your current refresh token. The JWT token will still be valid, but the only way to get a new refresh token is to log in again. This can be used by a client as part of a logout process if they wish.

#### Any background context you want to provide?
https://solidgeargroup.com/refresh-token-with-jwt-authentication-node-js