### PR TITLE
Feature/js refresh token config

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -22,6 +22,10 @@ const envVarsSchema = Joi.object({
         .description('Absolute or relative path to RSA public key'),
     JWT_TTL: Joi.number()
         .default(3600),
+    REFRESH_TOKEN_ENABLED: Joi.bool()
+        .default(false),
+    REFRESH_TOKEN_MULTIPLE_DEVICES: Joi.bool()
+        .default(false),
     PG_DB: Joi.string().required()
         .description('Postgres database name'),
     PG_PORT: Joi.number()
@@ -97,6 +101,10 @@ const config = {
     jwtPrivateKeyPath: envVars.JWT_PRIVATE_KEY_PATH,
     jwtPublicKeyPath: envVars.JWT_PUBLIC_KEY_PATH,
     jwtExpiresIn: envVars.JWT_TTL,
+    refreshToken: {
+        enabled: envVars.REFRESH_TOKEN_ENABLED,
+        multipleDevices: envVars.REFRESH_TOKEN_MULTIPLE_DEVICES,
+    },
     postgres: {
         db: envVars.PG_DB,
         port: envVars.PG_PORT,

--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -32,6 +32,11 @@ const authValidation = {
             refreshToken: Joi.string().required(),
         },
     },
+    refreshTokenReject: {
+        body: {
+            refreshToken: Joi.string().required(),
+        },
+    },
     resetToken: {
         body: {
             email: Joi.string().email().required(),

--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -26,6 +26,12 @@ const authValidation = {
             password: Joi.string().required(),
         },
     },
+    refreshToken: {
+        body: {
+            username: Joi.string().required(),
+            refreshToken: Joi.string().required(),
+        },
+    },
     resetToken: {
         body: {
             email: Joi.string().email().required(),

--- a/config/passport.js
+++ b/config/passport.js
@@ -24,31 +24,35 @@ const opts = {
 };
 
 module.exports = (passport) => {
-    passport.use(new JwtStrategy(opts, (jwtPayload, done) => {
+    const jwtStrategy = new JwtStrategy(opts, (jwtPayload, done) => {
         User.findOne({ where: { username: jwtPayload.username } })
             .then(user => done(null, user))
             .catch(err => done(err, false));
-    }));
+    });
+
+    const fbStrategy = new FacebookStrategy({
+        clientID: config.facebook.clientId,
+        clientSecret: config.facebook.clientSecret,
+        callbackURL: config.facebook.callbackUrl,
+        profileFields: ['email'],
+    }, (accessToken, refreshToken, profile, done) => {
+        const email = profile.emails[0].value;
+        User.findOrCreate({ where: {
+            username: email,
+            email,
+            provider: profile.provider,
+        } })
+        .spread((user) => {
+            if (user !== null) return done(null, user);
+            const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
+            return done(err);
+        });
+    });
+
+    passport.use(jwtStrategy);
 
     if (config.facebook.clientId) {
-        passport.use(new FacebookStrategy({
-            clientID: config.facebook.clientId,
-            clientSecret: config.facebook.clientSecret,
-            callbackURL: config.facebook.callbackUrl,
-            profileFields: ['email'],
-        }, (accessToken, refreshToken, profile, done) => {
-            const email = profile.emails[0].value;
-            User.findOrCreate({ where: {
-                username: email,
-                email,
-                provider: profile.provider,
-            } })
-            .spread((user) => {
-                if (user !== null) return done(null, user);
-                const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
-                return done(err);
-            });
-        }));
+        passport.use(fbStrategy);
     }
 };
 

--- a/config/passport.js
+++ b/config/passport.js
@@ -30,28 +30,28 @@ module.exports = (passport) => {
             .catch(err => done(err, false));
     });
 
-    const fbStrategy = new FacebookStrategy({
-        clientID: config.facebook.clientId,
-        clientSecret: config.facebook.clientSecret,
-        callbackURL: config.facebook.callbackUrl,
-        profileFields: ['email'],
-    }, (accessToken, refreshToken, profile, done) => {
-        const email = profile.emails[0].value;
-        User.findOrCreate({ where: {
-            username: email,
-            email,
-            provider: profile.provider,
-        } })
-        .spread((user) => {
-            if (user !== null) return done(null, user);
-            const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
-            return done(err);
-        });
-    });
-
     passport.use(jwtStrategy);
 
     if (config.facebook.clientId) {
+        const fbStrategy = new FacebookStrategy({
+            clientID: config.facebook.clientId,
+            clientSecret: config.facebook.clientSecret,
+            callbackURL: config.facebook.callbackUrl,
+            profileFields: ['email'],
+        }, (accessToken, refreshToken, profile, done) => {
+            const email = profile.emails[0].value;
+            User.findOrCreate({ where: {
+                username: email,
+                email,
+                provider: profile.provider,
+            } })
+            .spread((user) => {
+                if (user !== null) return done(null, user);
+                const err = new APIError('New facebook user not created', httpStatus.INTERNAL_SERVER_ERROR, true);
+                return done(err);
+            });
+        });
+
         passport.use(fbStrategy);
     }
 };

--- a/config/sequelize.js
+++ b/config/sequelize.js
@@ -25,6 +25,8 @@ const sequelize = new Sequelize(
 );
 
 db.User = sequelize.import('../server/models/user.model');
+db.RefreshToken = sequelize.import('../server/models/refreshToken.model');
+db.RefreshToken.belongsTo(db.User, { foreignKey: 'userId', targetKey: 'id' });
 
 // assign the sequelize variables to the db object and returning the db.
 module.exports = _.extend({

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "passport-jwt": "3.0.0",
     "pg": "6.1.6",
     "pg-hstore": "2.3.2",
+    "rand-token": "false0.4.0",
     "run-sequence": "^1.1.5",
     "sequelize": "^4.28.0",
     "snyk": "^1.40.0",

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -86,15 +86,10 @@ function submitRefreshToken(req, res, next) {
         };
 
         const jwtToken = signJWT(userInfo);
-        const refreshToken = randtoken.uid(128);
-
-        // save the refresh token
-        userResult.update({ refreshToken });
 
         return res.json({
             token: jwtToken,
             username: userResult.username,
-            refreshToken,
         });
     })
     .catch(error => next(error));

--- a/server/models/refreshToken.model.js
+++ b/server/models/refreshToken.model.js
@@ -1,6 +1,7 @@
 /* eslint no-param-reassign: ["error", { "props": false }] */
 /* eslint new-cap: 0 */
 import randtoken from 'rand-token';
+import config from '../../config/config';
 
 /**
  * User Schema
@@ -21,6 +22,15 @@ module.exports = (sequelize, DataTypes) => {
 
     RefreshToken.createNewToken = function createNewToken(userId) {
         const refreshToken = randtoken.uid(128);
+
+        if (!config.refreshToken.multipleDevices) {
+            return this.destroy({ where: { userId } })
+            .then(() => this.create({
+                token: refreshToken,
+                userId,
+            }));
+        }
+
         return this.create({
             token: refreshToken,
             userId,

--- a/server/models/refreshToken.model.js
+++ b/server/models/refreshToken.model.js
@@ -1,0 +1,31 @@
+/* eslint no-param-reassign: ["error", { "props": false }] */
+/* eslint new-cap: 0 */
+import randtoken from 'rand-token';
+
+/**
+ * User Schema
+ */
+module.exports = (sequelize, DataTypes) => {
+    const RefreshToken = sequelize.define('RefreshToken', {
+        id: {
+            type: DataTypes.INTEGER,
+            autoIncrement: true,
+            primaryKey: true,
+        },
+        token: {
+            type: DataTypes.STRING,
+            unique: true,
+            allowNull: false,
+        },
+    });
+
+    RefreshToken.createNewToken = function createNewToken(userId) {
+        const refreshToken = randtoken.uid(128);
+        return this.create({
+            token: refreshToken,
+            userId,
+        });
+    };
+
+    return RefreshToken;
+};

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -57,6 +57,9 @@ module.exports = (sequelize, DataTypes) => {
             type: DataTypes.ARRAY(DataTypes.STRING),
             defaultValue: [''],
         },
+        refreshToken: {
+            type: DataTypes.STRING,
+        },
         resetToken: {
             type: DataTypes.STRING,
         },

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -14,7 +14,7 @@ router.route('/login')
 router.route('/logout');
 
 router.route('/token/reject')
-    .post(validate(authValidation.refreshToken), authCtrl.rejectRefreshToken);
+    .post(validate(authValidation.refreshTokenReject), authCtrl.rejectRefreshToken);
 
 router.route('/token')
     .post(validate(authValidation.refreshToken), authCtrl.submitRefreshToken);

--- a/server/routes/auth.route.js
+++ b/server/routes/auth.route.js
@@ -13,6 +13,12 @@ router.route('/login')
 
 router.route('/logout');
 
+router.route('/token/reject')
+    .post(validate(authValidation.refreshToken), authCtrl.rejectRefreshToken);
+
+router.route('/token')
+    .post(validate(authValidation.refreshToken), authCtrl.submitRefreshToken);
+
 router.route('/update-password')
     .post(validate(authValidation.updatePassword), checkPassword,
           passport.authenticate('jwt', { session: false }),

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -133,6 +133,26 @@ describe('Auth API:', () => {
                 .expect(httpStatus.NOT_FOUND)
             )
         );
+
+        it('should allow multiple refresh tokens for multiple devices', () => request(app)
+            .post(`${common.baseURL}/auth/login`)
+            .send(common.validUserCredentials)
+            .expect(httpStatus.OK)
+            .then((res1) => {
+                expect(res1.body).to.have.property('refreshToken');
+                const token1 = res1.body.refreshToken;
+                return request(app)
+                    .post(`${common.baseURL}/auth/login`)
+                    .send(common.validUserCredentials)
+                    .expect(httpStatus.OK)
+                    .then((res2) => {
+                        expect(res2.body).to.have.property('refreshToken');
+                        const token2 = res2.body.refreshToken;
+                        expect(token1).to.not.equal(token2);
+                        return;
+                    });
+            })
+        );
     });
 
     describe('POST /auth/reset-password', () => {

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -122,7 +122,6 @@ describe('Auth API:', () => {
         it('should be able to expire refresh tokens', () => request(app)
             .post(`${common.baseURL}/auth/token/reject`)
             .send({
-                username: 'KK123',
                 refreshToken,
             })
             .expect(httpStatus.NO_CONTENT)

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -105,7 +105,6 @@ describe('Auth API:', () => {
                 expect(decoded.username).to.equal(common.validUserCredentials.username);
                 expect(decoded.email).to.equal(common.testUser.email);
                 expect(decoded.scopes).to.deep.equal(common.testUser.scopes);
-                refreshToken = res.body.refreshToken;
                 return;
             })
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4386,6 +4386,10 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+rand-token@false0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/rand-token/-/rand-token-0.4.0.tgz#1a565b6ad12d92dd4b30c4c4e5945e8aa24a5b3b"
+
 randomatic@^1.1.3:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"


### PR DESCRIPTION
#### What's this PR do?
Add config options for refresh tokens.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/SER-185

#### How should this be manually tested?
Start with both new env vars disabled, `REFRESH_TOKEN_ENABLED=false, REFRESH_TOKEN_MULTIPLE_DEVICES=false`. Make sure all refresh token routes return `NOT_IMPLEMENTED`, and that the standard login route does not return a refresh token.

Now enable refresh tokens. They should work as in SER-186.

Now enable multiple devices. You should be able to get separate refresh tokens working simultaneously from two different browsers/devices/clients.