### PR TITLE
update the docker build to use a multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # take default image of node boron i.e  node 6.x
-FROM node:8.9
+FROM node:8.9 as builder
 RUN npm i -g yarn
 
 # create app directory in container
@@ -16,12 +16,20 @@ RUN yarn
 # compile to ES5
 RUN yarn build
 
+FROM node:8.9 
+
+WORKDIR /app
+
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/node_modules ./node_modules
+
 # set up public and private keys
 RUN echo -e 'y\n'|ssh-keygen -q -t rsa -b 4096 -N "" -f private.key &&\
     openssl rsa -in private.key -pubout -outform PEM -out private.key.pub
+
 
 # expose port 4000
 EXPOSE 4000
 
 # cmd to start service
-CMD [ "node", "dist/index.js" ]
+CMD [ "node", "dist/index.js"]


### PR DESCRIPTION
This decreases the image size by 200MB but mostly is a change to demonstrate best practice on the build.

If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
makes for smaller, more precise docker images.  (this reduces the image size by between 100 and 200MB)
#### Related JIRA tickets:
none
#### How should this be manually tested?
docker build -t mytestbuild .
#### Any background context you want to provide?
This is mostly best practice.  While the security risk on yarn and other unnecessary packages are minimal, multi-stage builds are preferred.  This becomes significantly more important when building native packages for node (i.e. I would prefer final images to not have gcc as an example or ruby where it is used to compile the CSS).  
#### Screenshots (if appropriate):