### PR TITLE
SER-214 Customizable Mailer From Email Address

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
         - PG_PASSWD: postgres
         - MAILER_EMAIL_ID: ''
         - MAILER_PASSWORD: testpass
+        - MAILER_FROM_EMAIL_ADDRESS: ''
         - MAILER_SERVICE_PROVIDER: Gmail
       - image: circleci/postgres:9.6.2-alpine
         environment:

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ PG_CERT_CA=''
 ## Integration With Mail Service Provider ##
 MAILER_EMAIL_ID=
 MAILER_PASSWORD=
+MAILER_FROM_EMAIL_ADDRESS=
 MAILER_SERVICE_PROVIDER=
 
 ## Integration With Facebook for Login ##

--- a/config/config.js
+++ b/config/config.js
@@ -43,6 +43,7 @@ const envVarsSchema = Joi.object({
         .description('SSL certificate CA'), // Certificate itself, not a filename
     MAILER_EMAIL_ID: Joi.string().allow(''),
     MAILER_PASSWORD: Joi.string().allow(''),
+    MAILER_FROM_EMAIL_ADDRESS: Joi.string().allow(''),
     MAILER_SERVICE_PROVIDER: Joi.any().valid(
         '126',
         '163',
@@ -122,6 +123,7 @@ const config = {
     mailer: {
         user: envVars.MAILER_EMAIL_ID,
         password: envVars.MAILER_PASSWORD,
+        fromAddress: envVars.MAILER_FROM_EMAIL_ADDRESS,
         service: envVars.MAILER_SERVICE_PROVIDER,
     },
     facebook: {

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -43,6 +43,8 @@ spec:
           value: ''
         - name: MAILER_PASSWORD
           value: ''
+        - name: MAILER_FROM_EMAIL_ADDRESS
+          value: ''
         - name: MAILER_SERVICE_PROVIDER
           value: '126'
         - name: FACEBOOK_CLIENT_ID

--- a/server/helpers/mailer.js
+++ b/server/helpers/mailer.js
@@ -6,7 +6,7 @@ module.exports = {
 
     sendEmail(res, email, text, token, next) {
         const options = {
-            from: util.format('"%s"', config.mailer.user),
+            from: util.format('"%s"', config.mailer.fromAddress),
             to: email,
             subject: 'Password Reset',
             text,


### PR DESCRIPTION
#### What's this PR do?
Before the fix:

MAILER_EMAIL_ID was used both as the username/email used to login to the service specified by MAILER_SERVICE_PROVIDER, and as the "from" email address on the automated email.

This does not work with certain service providers such as mailgun, which requires/sets up a different email address than the one associated with the account to send emails from.

The fix:

Add env var MAILER_FROM_EMAIL_ADDRESS and change the call to nodemailer to use this for he from address.

#### Related JIRA tickets:
* [SER-214](https://jira.amida-tech.com/browse/SER-214)

#### How should this be manually tested?
1. Set the MAILER_ env vars (thorough description and examples of how to set them in README.md).
2. If using the orange app, on the login screen, click the "I forgot my password button" and enter your email address. You should receive a password reset email from the address specified by MAILER_FROM_EMAIL_ADDRESS. Not using the orange app, I don't know how to get some other app/service to call the Auth Service to get it to send a password reset email.
