### PR TITLE
Bug/ser 216 forgot password sniffable emails

### DIFF
--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -171,7 +171,7 @@ function resetToken(req, res, next) {
             const text = util.format('%s\n%s\n%s\n\n%s\n', userLine, clickLine, link, ifNotLine);
             sendEmail(res, email, text, token, next);
         })
-        .catch(error => next(error));
+        .catch(() => res.status(200).end());
 }
 
 /**

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -27,7 +27,7 @@ function login(req, res, next) {
 
     const passwordMatch = user.then((userResult) => {
         if (_.isNull(userResult)) {
-            const err = new APIError('Username not found', 'UNKNOWN_USERNAME', httpStatus.NOT_FOUND, true);
+            const err = new APIError('Incorrect username or password', 'INCORRECT_USERNAME_OR_PASSWORD', httpStatus.NOT_FOUND, true);
             return next(err);
         }
         return userResult.testPassword(params.password);
@@ -36,7 +36,7 @@ function login(req, res, next) {
     // once the user and password promises resolve, send the token or an error
     Promise.join(user, passwordMatch, (userResult, passwordMatchResult) => {
         if (!passwordMatchResult) {
-            const err = new APIError('Incorrect password', 'INCORRECT_PASSWORD', httpStatus.UNAUTHORIZED, true);
+            const err = new APIError('Incorrect username or password', 'INCORRECT_USERNAME_OR_PASSWORD', httpStatus.NOT_FOUND, true);
             return next(err);
         }
 
@@ -171,7 +171,7 @@ function resetToken(req, res, next) {
             const text = util.format('%s\n%s\n%s\n\n%s\n', userLine, clickLine, link, ifNotLine);
             sendEmail(res, email, text, token, next);
         })
-        .catch(() => res.status(200).end());
+        .catch(error => next(error));
 }
 
 /**

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -230,6 +230,13 @@ describe('Auth API:', () => {
                 })
         );
 
+        it('should accept the invalid email', () =>
+            request(app)
+                .post(`${common.baseURL}/auth/reset-password`)
+                .send({ email: 'fakeemail@fakesite.com' })
+                .expect(httpStatus.OK)
+        );
+
         it('should update the password', () =>
             request(app)
                 .post(`${common.baseURL}/auth/reset-password`)

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -33,10 +33,10 @@ describe('Auth API:', () => {
         it('should return 401 error with bad password', () =>
             request(app).post(`${common.baseURL}/auth/login`)
                 .send(common.badPassword)
-                .expect(httpStatus.UNAUTHORIZED)
+                .expect(httpStatus.NOT_FOUND)
                 .then((res) => {
-                    expect(res.body.message).to.equal('Incorrect password');
-                    expect(res.body.code).to.equal('INCORRECT_PASSWORD');
+                    expect(res.body.message).to.equal('Incorrect username or password');
+                    expect(res.body.code).to.equal('INCORRECT_USERNAME_OR_PASSWORD');
                     expect(res.body.status).to.equal('ERROR');
                 })
         );
@@ -46,8 +46,8 @@ describe('Auth API:', () => {
                 .send(common.missingUsername)
                 .expect(httpStatus.NOT_FOUND)
                 .then((res) => {
-                    expect(res.body.message).to.equal('Username not found');
-                    expect(res.body.code).to.equal('UNKNOWN_USERNAME');
+                    expect(res.body.message).to.equal('Incorrect username or password');
+                    expect(res.body.code).to.equal('INCORRECT_USERNAME_OR_PASSWORD');
                     expect(res.body.status).to.equal('ERROR');
                 })
         );
@@ -228,13 +228,6 @@ describe('Auth API:', () => {
                         .expect(httpStatus.OK)
                         .then(res2 => expect(res2.text).to.equal('OK'));
                 })
-        );
-
-        it('should accept the invalid email', () =>
-            request(app)
-                .post(`${common.baseURL}/auth/reset-password`)
-                .send({ email: 'fakeemail@fakesite.com' })
-                .expect(httpStatus.OK)
         );
 
         it('should update the password', () =>


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
Returns the same response for an invalid account and invalid password

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/SER-216
#### How should this be manually tested?
Post invalid and valid email and password combinations to login verifying the response in the same

Can also be tested in conjunction with
https://github.com/amida-tech/orange-ignite/pull/172

#### Any background context you want to provide?
#### Screenshots (if appropriate):