### PR TITLE
Feature/ser 220 return ttl with auth

### DIFF
--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -24,7 +24,6 @@ const RefreshToken = db.RefreshToken;
 function login(req, res, next) {
     const params = _.pick(req.body, 'username', 'password');
     const user = User.findOne({ where: { username: params.username } });
-
     const passwordMatch = user.then((userResult) => {
         if (_.isNull(userResult)) {
             const err = new APIError('Username not found', 'UNKNOWN_USERNAME', httpStatus.NOT_FOUND, true);
@@ -55,11 +54,13 @@ function login(req, res, next) {
                 token: jwtToken,
                 username: user.username,
                 refreshToken: token.token,
+                ttl: config.jwtExpiresIn,
             }));
         }
         return res.json({
             token: jwtToken,
             username: user.username,
+            ttl: config.jwtExpiresIn,
         });
     })
     .catch(error => next(error));

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -101,6 +101,7 @@ function submitRefreshToken(req, res, next) {
             return res.json({
                 token: jwtToken,
                 username: userResult.username,
+                ttl: config.jwtExpiresIn,
             });
         })
     )


### PR DESCRIPTION
#### What's this PR do?
This feature changes logins and refresh token requests to include the TTL (time to live) with any requests. After checking with Mike, it's pretty common to do this. TTL can be ignored at your leisure, but I could use it for INBA-743. 

**Please test this with INBA-743.**
