### PR TITLE
requiring old password to allow updating password

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -23,6 +23,7 @@ const userValidation = {
 const authValidation = {
     updatePassword: {
         body: {
+            oldPassword: Joi.string().required(),
             password: Joi.string().required(),
         },
     },

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -149,11 +149,11 @@ function updatePassword(req, res, next) {
 
     if (!user.testPassword(params.oldPassword)) {
         const err = new APIError('Incorrect password', 'INCORRECT_PASSWORD', httpStatus.FORBIDDEN, true);
-        next(err);
+        return next(err);
     }
 
     user.password = params.password;
-    user.save()
+    return user.save()
         .then(() => res.sendStatus(httpStatus.OK))
         .catch(error => next(error));
 }

--- a/server/tests/integration/auth.integration.spec.js
+++ b/server/tests/integration/auth.integration.spec.js
@@ -286,11 +286,11 @@ describe('Auth API:', () => {
             })
         );
 
-        it('should update user password when user is authenticated', () =>
+        it('should update user password when user is authenticated and oldPassword is correct', () =>
             request(app)
                 .post(`${common.baseURL}/auth/update-password`)
                 .set('Authorization', jwtToken)
-                .send({ password: 'Newerpass123' })
+                .send({ oldPassword: common.validUserCredentials.password, password: 'Newerpass123' })
                 .expect(httpStatus.OK)
                 .then((res) => {
                     expect(res.text).to.equal('OK');
@@ -303,10 +303,23 @@ describe('Auth API:', () => {
                 })
         );
 
+        it('should return 403 when user is authenticated but oldPassword is incorrect', () =>
+            request(app)
+                .post(`${common.baseURL}/auth/update-password`)
+                .set('Authorization', jwtToken)
+                .send({ oldPassword: 'incorrect pass', password: 'Newerpass123' })
+                .expect(httpStatus.FORBIDDEN)
+                .then((res) => {
+                    expect(res.body.message).to.equal('Incorrect password');
+                    expect(res.body.code).to.equal('INCORRECT_PASSWORD');
+                    expect(res.body.status).to.equal('ERROR');
+                })
+        );
+
         it('should return 401 when user is not authenticated', () =>
             request(app)
                 .post(`${common.baseURL}/auth/update-password`)
-                .send({ password: 'Newerpass123' })
+                .send({ oldPassword: common.validUserCredentials.password, password: 'Newerpass123' })
                 .expect(httpStatus.UNAUTHORIZED)
                 .then(res => expect(res.text).to.equal('Unauthorized'))
         );
@@ -315,7 +328,7 @@ describe('Auth API:', () => {
             request(app)
                 .post(`${common.baseURL}/auth/update-password`)
                 .set('Authorization', 'Bearer BadJWT')
-                .send({ password: 'Newerpass123' })
+                .send({ oldPassword: common.validUserCredentials.password, password: 'Newerpass123' })
                 .expect(httpStatus.UNAUTHORIZED)
                 .then(res => expect(res.text).to.equal('Unauthorized'))
         );
@@ -324,7 +337,7 @@ describe('Auth API:', () => {
             request(app)
                 .post(`${common.baseURL}/auth/update-password`)
                 .set('Authorization', jwtToken)
-                .send({ password: 'badpass' })
+                .send({ oldPassword: common.validUserCredentials.password, password: 'badpass' })
                 .expect(httpStatus.BAD_REQUEST)
                 .then(res => expect(res.text).to.contain('must be at least 8 characters long'))
         );


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
As suggested in Orange-707, this adds a current password check to the `update-password` endpoint.
If the current password isn't correct, it returns a 403 forbidden.
if the current password is correct, it works as normal.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/ORANGE-707

#### How should this be manually tested?
Via postman:
* login as a valid user
  * include your token in the following requests
* POST to the update-password endpoint with a body a la

```
{
  oldPassword: 'wrong',
  password: 'Newpass1!'
}
```
> this should fail with a 403
* POST to the update-password endpoint with a body a la

```
{
  oldPassword: 'CorrectPasswordForTheLoggedInUser',
  password: 'Newpass1!'
}
```
> this should succeed like before

#### Any background context you want to provide?
When an attacker finds a user session that was left logged in, they have access for the duration of that session. To extend their access, they may attempt to change the password. Right now, there is nothing stopping them. With this PR, they will need to know the password to the account to change the password even though they already have an active session.

This attack scenario is not unreasonable. In the case of a website, a user may accidentally leave a session open on a shared computer. For mobile applications, a user may leave their phone on a table unlocked, or allow a stranger to user their phone temporarily.

#### Screenshots (if appropriate):
NA