### PR TITLE
Orange 487 Make password rest URI configurable via env var

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -35,3 +35,7 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# The Dockerfile builds these, so don't copy them from your local dir
+private.key
+private.key.pub

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 ## Auth Microservice ##
 NODE_ENV=development
 JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
+AUTH_MICROSERVICE_URL=http://localhost:4000/api/v1
 // AUTH_SERVICE_PORT=
 AUTH_SERVICE_ONLY_ADMIN_CAN_CREATE_USERS=false
 

--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,7 @@
 ## Auth Microservice ##
 NODE_ENV=production
 JWT_SECRET=
+AUTH_MICROSERVICE_URL=https://amida-auth-microservice:4000/api/v1
 // AUTH_SERVICE_PORT=
 AUTH_SERVICE_ONLY_ADMIN_CAN_CREATE_USERS=false
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,14 @@ A description of what the variable is or does.
 First, see description of `AUTH_SERVICE_JWT_MODE`. When `AUTH_SERVICE_JWT_MODE=hmac`, this is the shared secret between this service an all services using this service for authentication. Therefore, all other such service must set their `JWT_SECRET` to match this value.
 - In production, this should be set to a value different than the one in `.env.example`.
 
+##### `AUTH_MICROSERVICE_URL`
+
+URL of this service's API. It must be defined because this service uses it to generate its password reset link URLs.
+- `.env.production` sets this to to `https://amida-auth-microservice:4000/api/v1`, which assumes:
+  - `amida-auth-microservice` is the name of the docker container running the Auth Service.
+  - `4000` is the port the Auth Service is running on in its container.
+  - The Auth Service's docker container and this service's docker container are a part of the same docker network.
+
 ##### `AUTH_SERVICE_PORT` (Required) [`4000`]
 
 The port this server will run on.

--- a/config/config.js
+++ b/config/config.js
@@ -46,6 +46,8 @@ const envVarsSchema = Joi.object({
         .description('Admin email for seeding only'),
     AUTH_SERVICE_PG_DB: Joi.string().required()
         .description('Postgres database name'),
+    AUTH_MICROSERVICE_URL: Joi.string()
+        .description('This is the base of the URL used for password reset links. Omit any trailing slash. e.g. https://the-auth-service.com/api/v1'),
     AUTH_SERVICE_PG_PORT: Joi.number()
         .default(5432),
     AUTH_SERVICE_PG_HOST: Joi.string(),
@@ -116,6 +118,7 @@ if (error) {
 
 const config = {
     env: envVars.NODE_ENV,
+    authMicroserviceUrl: envVars.AUTH_MICROSERVICE_URL,
     port: envVars.AUTH_SERVICE_PORT,
     onlyAdminCanCreateUsers: envVars.AUTH_SERVICE_ONLY_ADMIN_CAN_CREATE_USERS,
     jwtMode: envVars.AUTH_SERVICE_JWT_MODE,

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -169,7 +169,7 @@ function resetToken(req, res, next) {
     }
     return User.resetPasswordToken(email, 3600)
         .then((token) => {
-            const link = generateLink(req, token);
+            const link = generateLink(token);
             const text = util.format('%s\n%s\n%s\n\n%s\n', userLine, clickLine, link, ifNotLine);
             sendEmail(res, email, text, token, next);
         })

--- a/server/helpers/mailer.js
+++ b/server/helpers/mailer.js
@@ -32,8 +32,8 @@ module.exports = {
         }
     },
 
-    generateLink(req, token) {
-        return util.format('%s/reset-password/%s', req.headers.origin, token);
+    generateLink(token) {
+        return util.format('%s/reset-password/%s', config.authMicroserviceUrl, token);
     },
 
 };


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
See the Jira ticket.

#### Related JIRA tickets:
[ORANGE-478](https://jira.amida-tech.com/browse/ORANGE-478)

#### How should this be manually tested?
Set env var `AUTH_MICROSERVICE_URL`
Set the `AUTH_SERVICE_MAILER_...` env vars
Use a client such as the orange app's "forgot password?" functionality.
You should get an email and in that email the password reset link should be `{whatever you set your AUTH_MICROSERVICE_URL to}/reset-password/{the token}`

#### Any background context you want to provide?
Nope.

#### Screenshots (if appropriate):
In the following case, I set `AUTH_MICROSERVICE_URL=http://localhost:4000/api/v1`:
![image](https://user-images.githubusercontent.com/5943087/45451178-4731b100-b6a8-11e8-8230-094b845b200a.png)
