### PR TITLE
Make log level configurable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-## Auth Microservice ##
+## Shared ##
 NODE_ENV=development
+LOG_LEVEL=info
+
+## Auth Microservice ##
 JWT_SECRET=0a6b944d-d2fb-46fc-a85e-0295c986cd9f
 AUTH_MICROSERVICE_URL=http://localhost:4000/api/v1
 // AUTH_SERVICE_PORT=

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,8 @@
+## Shared ##
+NODE_ENV=development
+LOG_LEVEL=info
+
 ## Auth Microservice ##
-NODE_ENV=production
 JWT_SECRET=
 AUTH_MICROSERVICE_URL=https://amida-auth-microservice:4000/api/v1
 // AUTH_SERVICE_PORT=

--- a/README.md
+++ b/README.md
@@ -304,6 +304,10 @@ A description of what the variable is or does.
 
 - Valid values are `development`, `production`, and `test`.
 
+##### `LOG_LEVEL` [`info`]
+
+- Valid values are [winston](https://github.com/winstonjs/winston) logging levels (`error`, `warn`, etc.).
+
 ##### `JWT_SECRET` (Required)
 
 First, see description of `AUTH_SERVICE_JWT_MODE`. When `AUTH_SERVICE_JWT_MODE=hmac`, this is the shared secret between this service an all services using this service for authentication. Therefore, all other such service must set their `JWT_SECRET` to match this value.

--- a/config/config.js
+++ b/config/config.js
@@ -14,6 +14,8 @@ const envVarsSchema = Joi.object({
     NODE_ENV: Joi.string()
         .allow(['development', 'production', 'test', 'provision'])
         .default('production'),
+    LOG_LEVEL: Joi.string()
+        .default('info'),
     AUTH_SERVICE_PORT: Joi.number()
         .default(4000),
     AUTH_SERVICE_ONLY_ADMIN_CAN_CREATE_USERS: Joi.bool()
@@ -118,6 +120,7 @@ if (error) {
 
 module.exports = {
     env: envVars.NODE_ENV,
+    logLevel: envVars.LOG_LEVEL,
     authMicroserviceUrl: envVars.AUTH_MICROSERVICE_URL,
     port: envVars.AUTH_SERVICE_PORT,
     onlyAdminCanCreateUsers: envVars.AUTH_SERVICE_ONLY_ADMIN_CAN_CREATE_USERS,

--- a/config/winston.js
+++ b/config/winston.js
@@ -5,7 +5,7 @@ const { createLogger, transports, format } = require('winston');
 const { printf, timestamp, combine, colorize } = format;
 
 const logger = createLogger({
-    level: 'info',
+    level: config.logLevel,
     transports: [
         new transports.Console(),
     ],

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ db.sequelize
   })
   .then(startServer)
   .catch((err) => {
-      if (err) logger.debug('An error occured %j', err);
+      if (err) logger.debug('An error occured', err);
       else logger.debug('Database synchronized');
   });
 


### PR DESCRIPTION
#### What's this PR do?
Makes the winston logging level configurable via the `LOG_LEVEL` environment variable.

#### Related JIRA tickets:

[ORANGE-852](https://jira.amida.com/browse/ORANGE-852)

#### How should this be manually tested?

1. Set your `LOG_LEVEL` in your `.env` file to any valid winston level (see winston documentation or the code below for valid levels)

2. Add these lines to any file (`index.js` would work nice).
```js
logger.error('this is error');
logger.warn('this is warn');
logger.info('this is info');
logger.verbose('this is verbose');
logger.debug('this is debug');
logger.silly('this is silly');
```
3. `yarn start` and ensure you only see print the statements of the level you set and levels below it. Ex, if `LOG_LEVEL=info`, you should only see print:
```sh
this is error
this is warn
this is info
```

4. Repeat the same process without `LOG_LEVEL` defined, and you should see things log at the `info` level.