### PR TITLE
 hotfix/enable-docker-image-to-run-migration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,3 +40,6 @@ jspm_packages
 # The Dockerfile builds these, so don't copy them from your local dir
 private.key
 private.key.pub
+
+# Environment variables files
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,7 @@ FROM node:8.9
 
 WORKDIR /app
 
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app /app
 
 # set up public and private keys
 RUN echo -e 'y\n'|ssh-keygen -q -t rsa -b 4096 -N "" -f private.key &&\


### PR DESCRIPTION
## What's this PR do?

Enables DB migrations (and undos) to be run by the docker image.

Previously, not all the files necessary for migrations to run were run were copied in the Dockerfile from the builder image to the runner image.

## Related JIRA tickets:

The ticket for this PR is
https://jira.amida.com/browse/ORANGE-903

The technical debt cleanup ticket for later is
https://jira.amida.com/browse/ORANGE-904

## How should this be manually tested?

1. Docker build this version of the code.
```sh
cd /your/auth-service/git/repo/dir
git checkout this-version-of-the-code
docker build -t some/image:version .
```
2. Run the docker image properly using `docker run` (see README.md)
3. Login to the image using `docker exec -it your-image-name /bin/bash`
4. Run the migration:

WARNING: only do the following on a DB you don't care about potientially having to blow away.

`yarn migrate` (or `yarn migrate:undo`)

## Any background context you want to provide?

This is necessary so that production code (this service when it's dockerized, such as when running in k8s), can run the migrations.
