### PR TITLE
Fixing 500 from invalid credentials

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -91,21 +91,22 @@ app.use((req, res, next) => {
     return next(err);
 });
 
-// log error in winston transports except when executing test suite
-if (config.env !== 'test') {
-    app.use(expressWinston.errorLogger({
-        winstonInstance,
-    }));
-}
-
 // error handler, send stacktrace only during development
 app.use((err, req, res, next) => // eslint-disable-line no-unused-vars
-    res.status(err.status).json({
+    res.status(err.status || 500).json({
         code: err.isPublic ? err.message.code : 'UNKNOWN_ERROR',
         status: 'ERROR',
         message: err.isPublic ? err.message.message : httpStatus[err.status],
         stack: config.env === 'development' ? err.stack : {},
     })
 );
+
+
+// log error in winston transports except when executing test suite
+if (config.env !== 'test') {
+    app.use(expressWinston.errorLogger({
+        winstonInstance,
+    }));
+}
 
 export default app;


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
Fixes a 500 return when supplying invalid credentials 

#### Related JIRA tickets:
https://jira.amida.com/browse/ORANGE-863
https://jira.amida.com/browse/ORANGE-909

#### How should this be manually tested?
Post to `/login` with invalid credentials from postman or Orange-Mobile
Verify it returns a 404

#### Any background context you want to provide?
#### Screenshots (if appropriate):