### PR TITLE
add migration for userId on refreshToken table if it doesnt exist

### DIFF
--- a/server/migrations/20181114172213-userId-refreshToken.js
+++ b/server/migrations/20181114172213-userId-refreshToken.js
@@ -5,7 +5,7 @@ module.exports = {
       Add altering commands here.
       Return a promise to correctly handle asynchronicity.
       */
-        return queryInterface.sequelize.query('ALTER TABLE "refreshToken" ADD COLUMN IF NOT EXISTS "userId" INTEGER;');
+        return queryInterface.sequelize.query('ALTER TABLE "refreshToken" ADD COLUMN IF NOT EXISTS "userId" INTEGER; ALTER TABLE "refreshToken" DROP COLUMN IF EXISTS "uuid";');
     },
     down(queryInterface) {
         return true;

--- a/server/migrations/20181114172213-userId-refreshToken.js
+++ b/server/migrations/20181114172213-userId-refreshToken.js
@@ -1,0 +1,13 @@
+
+module.exports = {
+    up(queryInterface) {
+    /*
+      Add altering commands here.
+      Return a promise to correctly handle asynchronicity.
+      */
+        return queryInterface.sequelize.query('ALTER TABLE "refreshToken" ADD COLUMN IF NOT EXISTS "userId" INTEGER;');
+    },
+    down(queryInterface) {
+        return true;
+    },
+};


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
Add's userId column to refreshToken table as a migration if it doesn't exist. Doesn't undo column if migration is undone (due to the column creation now being in original table creation script)
#### Related JIRA tickets:
#### How should this be manually tested?
