### PR TITLE
disallowing registrar scopes to create new users with a registrar or admin scope

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -96,7 +96,7 @@ function create(req, res, next) {
     // if current user is admin or a registrar, allow them to include
     // scopes on creation
     // however, don't allow registrar to create more registrars, only admin can do that
-    if (potentialScopes) {
+    if (potentialScopes && req.user) {
         if (req.user.scopes.includes('admin')) {
             // we are admin
             user.scopes = potentialScopes;

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -3,6 +3,7 @@ import httpStatus from 'http-status';
 import db from '../../config/sequelize';
 import APIError from '../helpers/APIError';
 import { signJWT } from '../helpers/jwt';
+import config from '../../config/config';
 
 const User = db.User;
 
@@ -90,10 +91,28 @@ function create(req, res, next) {
         username: req.body.username,
         email: req.body.email,
         password: req.body.password,
-        scopes: req.body.scopes,
     });
+    const potentialScopes = req.body.scopes;
+    // if current user is admin or a registrar, allow them to include
+    // scopes on creation
+    // however, don't allow registrar to create more registrars, only admin can do that
+    if (potentialScopes) {
+        if (req.user.scopes.includes('admin')) {
+            // we are admin
+            user.scopes = potentialScopes;
+        } else if (req.user.scopes.some(scope => config.registrarScopes.includes(scope))) {
+            // we are not admin but are registrar
+            // if trying to create new registrar or admin, return forbidden
+            if (potentialScopes.some(scope => ['admin', ...config.registrarScopes].includes(scope))) {
+                const e = new APIError('Registrar not allowed to create new admin or registrar users', 'CANNOT_CREATE_ADMIN', httpStatus.FORBIDDEN, true);
+                return next(e);
+            }
+            // else go ahead
+            user.scopes = potentialScopes;
+        }
+    }
 
-    user.save().then((savedUser) => {
+    return user.save().then((savedUser) => {
         const userInfo = savedUser.getBasicUserInfo();
         userInfo.jwtToken = signJWT(userInfo);
         res.json(userInfo);

--- a/server/migrations/20181114172213-userId-refreshToken.js
+++ b/server/migrations/20181114172213-userId-refreshToken.js
@@ -7,7 +7,7 @@ module.exports = {
       */
         return queryInterface.sequelize.query('ALTER TABLE "refreshToken" ADD COLUMN IF NOT EXISTS "userId" INTEGER; ALTER TABLE "refreshToken" DROP COLUMN IF EXISTS "uuid";');
     },
-    down(queryInterface) {
+    down() {
         return true;
     },
 };


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.
#### What's this PR do?
This disallows registrar users from creating new registrar users. Only admin can do that.
#### Related JIRA tickets:
ORANGE-1017
#### How should this be manually tested?
make sure you're .env has something like this:

```bash
AUTH_SERVICE_PUBLIC_REGISTRATION=false
AUTH_SERVICE_REGISTRAR_SCOPES=["programAdministrator"]
```

As an admin user create a new user with the registrar scope (in this case: `"programAdministrator"`)

```
POST /api/v1/user
{
  "username": "PA",
  "email": "pa@example.com",
  "password": "Password1!",
  "scopes": ["programAdministrator"]
}
```
That should work.


Now login as that newly created programAdministrator and try to create a new programAdminstrator using a similar request to above.
That should fail with a descriptive error message.

---
We should also go ahead and test this via the orange-api.

So using the admin user create a user via orange-api
```
POST /v1/user
{
  "first_name": "program",
  "last_name": "admin",
  "email": "pa2@example.com",
  "password": "Password1!",
  "role": "programAdministrator"
}
```
That should work.

Now using that newly created programAdministrator, try to create a new programAdministrator. You can even try this via orange-web. This should fail.
#### Any background context you want to provide?
#### Screenshots (if appropriate):