### PR TITLE
[SER-275] Replace winston.errorLogger with winston.warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - `auth.controller.js` `login()` no longer throws duplicate errors for incorrect username or password.
+- Remove `app.use(winstonInstance.errorLogger())` and replace with err handling middlware that calls `winstonInstance.info(err)`
 
 ## [2.7.0] -- 2019-02-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 ## [Unreleased]
-### Changed
-- `auth.controller.js` `login()` no longer throws duplicate errors for incorrect username or password.
-- Remove `app.use(winstonInstance.errorLogger())` and replace with err handling middlware that calls `winstonInstance.info(err)`
+### Fixed
+- `auth.controller.js:login()` no longer throws duplicate errors for incorrect username or password
+- Use error handling middlware `winstonInstance.info(err)`
+  * Previously, `winstonInstance.errorLogger()` always threw a `TypeError`, meaning the underlying error didn't actually show in the logs
+
 
 ## [2.7.0] -- 2019-02-04
 ### Added

--- a/src/config/express.js
+++ b/src/config/express.js
@@ -86,6 +86,14 @@ app.use((req, res, next) => {
     return next(err);
 });
 
+// Log errors.
+if (config.env !== 'test') {
+    app.use((err, req, res, next) => {
+        winstonInstance.warn(err);
+        return next(err);
+    });
+}
+
 // error handler, send stacktrace only during development
 app.use((err, req, res, next) => // eslint-disable-line no-unused-vars
     res.status(err.status || 500).json({
@@ -95,13 +103,5 @@ app.use((err, req, res, next) => // eslint-disable-line no-unused-vars
         stack: config.env === 'development' ? err.stack : {},
     })
 );
-
-
-// log error in winston transports except when executing test suite
-if (config.env !== 'test') {
-    app.use(expressWinston.errorLogger({
-        winstonInstance,
-    }));
-}
 
 export default app;


### PR DESCRIPTION
#### Jira Tickets

https://jira.amida.com/browse/SER-275

#### What's this PR do?

See Jira ticket.

#### How should this be manually tested?

**Test 1**: `yarn test`, and note that you don't get loads of logging for each test.

**Test 2**: Make an incorrect API call. You should the see the actual error you caused (not always the exact same error, namely "TypeError: Cannot read property 'getAllInfo' of undefined") logged at warn level.

Example incorrect API call:

`POST` to `/api/v2/auth/login` with body
```
{
  "username": "something",
  "password": "something"
}
```

 with an incorrect username and/or incorrect password, and you should get...

**Test 2 Case A**: When `NODE_ENV=development`, you should get logging statement:

`2019-04-08T17:02:17.562Z warn: [object Object]`

Note: This `[object Object]` will be fixed (made readable and useful) by some soon-to-be implemented changes in `amida-tech/winston-json-formatter`.

**Test 2 Case B**: When `NODE_ENV=production`, you should get logging statement something like:

```
{"service":"amida-auth-service","logger":"application-logger","hostname":"aaron-macbook","level":"warn","msg":{"status":"ERROR","message":"Incorrect username or password","code":"INCORRECT_USERNAME_OR_PASSWORD"},"meta":{"service":{"version":"2.7.0","node_env":"production"},"logger":{"time":"2019-04-08T17:19:57.301Z"},"event":{"code":"INCORRECT_USERNAME_OR_PASSWORD","status":404,"isPublic":true,"isOperational":true}},"err":{"name":"APIError","stack":"APIError: [object Object]\n    at APIError.ExtendableError (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/src/helpers/APIError.js:61:11)\n    at new APIError (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/src/helpers/APIError.js:90:71)\n    at /Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/src/controllers/auth.controller.js:49:17\n    at tryCatcher (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/util.js:16:23)\n    at Promise._settlePromiseFromHandler (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/promise.js:512:31)\n    at Promise._settlePromise (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/promise.js:569:18)\n    at Promise._settlePromise0 (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/promise.js:614:10)\n    at Promise._settlePromises (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/promise.js:694:18)\n    at _drainQueueStep (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/async.js:138:12)\n    at _drainQueue (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/async.js:131:9)\n    at Async._drainQueues (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/async.js:147:5)\n    at Immediate.Async.drainQueues (/Users/houli/docs/gitrepos/amida-tech/amida-auth-microservice-2/node_modules/sequelize/node_modules/bluebird/js/release/async.js:17:14)\n    at runCallback (timers.js:794:20)\n    at tryOnImmediate (timers.js:752:5)\n    at processImmediate [as _immediateCallback] (timers.js:729:5)"}}
```
